### PR TITLE
feat(ux): add animated gradient border branding for RL experiments

### DIFF
--- a/css/experiment-highlight.css
+++ b/css/experiment-highlight.css
@@ -1,0 +1,50 @@
+/**
+ * @file
+ * Styles for highlighting RL experiments in the UI.
+ *
+ * This CSS is only loaded for users with 'view rl reports' permission.
+ * Integrating modules can add the 'rl-experiment' class to their elements
+ * to apply the animated rainbow border branding.
+ */
+
+:root {
+  --rl-color-1: #0077B6;
+  --rl-color-2: #0096C7;
+  --rl-color-3: #00B4D8;
+  --rl-color-4: #48CAE4;
+  --rl-color-5: #26828E;
+  --rl-color-6: #1F9E89;
+  --rl-color-7: #35B779;
+  --rl-color-8: #6CCE59;
+  --rl-color-9: #B4DE2C;
+  --rl-color-10: #DAE319;
+}
+
+@keyframes rl-rainbow-border {
+  0% {
+    border-image: linear-gradient(90deg, var(--rl-color-1), var(--rl-color-2), var(--rl-color-3), var(--rl-color-4), var(--rl-color-5), var(--rl-color-6), var(--rl-color-7), var(--rl-color-8), var(--rl-color-9), var(--rl-color-10)) 1;
+  }
+  20% {
+    border-image: linear-gradient(90deg, var(--rl-color-3), var(--rl-color-4), var(--rl-color-5), var(--rl-color-6), var(--rl-color-7), var(--rl-color-8), var(--rl-color-9), var(--rl-color-10), var(--rl-color-1), var(--rl-color-2)) 1;
+  }
+  40% {
+    border-image: linear-gradient(90deg, var(--rl-color-5), var(--rl-color-6), var(--rl-color-7), var(--rl-color-8), var(--rl-color-9), var(--rl-color-10), var(--rl-color-1), var(--rl-color-2), var(--rl-color-3), var(--rl-color-4)) 1;
+  }
+  60% {
+    border-image: linear-gradient(90deg, var(--rl-color-7), var(--rl-color-8), var(--rl-color-9), var(--rl-color-10), var(--rl-color-1), var(--rl-color-2), var(--rl-color-3), var(--rl-color-4), var(--rl-color-5), var(--rl-color-6)) 1;
+  }
+  80% {
+    border-image: linear-gradient(90deg, var(--rl-color-9), var(--rl-color-10), var(--rl-color-1), var(--rl-color-2), var(--rl-color-3), var(--rl-color-4), var(--rl-color-5), var(--rl-color-6), var(--rl-color-7), var(--rl-color-8)) 1;
+  }
+  100% {
+    border-image: linear-gradient(90deg, var(--rl-color-1), var(--rl-color-2), var(--rl-color-3), var(--rl-color-4), var(--rl-color-5), var(--rl-color-6), var(--rl-color-7), var(--rl-color-8), var(--rl-color-9), var(--rl-color-10)) 1;
+  }
+}
+
+.rl-experiment,
+.contextual-links li a[href*="/admin/reports/rl/experiment/"],
+.rl-admin-page .page-title {
+  animation: rl-rainbow-border 10s linear infinite !important;
+  border-width: 3px !important;
+  border-style: solid !important;
+}

--- a/rl.libraries.yml
+++ b/rl.libraries.yml
@@ -1,3 +1,9 @@
+experiment-highlight:
+  version: 1.0
+  css:
+    theme:
+      css/experiment-highlight.css: {}
+
 plotly:
   version: 2.35.2
   license:

--- a/rl.module
+++ b/rl.module
@@ -41,6 +41,27 @@ function rl_theme() {
 }
 
 /**
+ * Implements hook_page_attachments().
+ */
+function rl_page_attachments(array &$attachments) {
+  // Attach experiment highlight styles for users who can view RL reports.
+  if (\Drupal::currentUser()->hasPermission('view rl reports')) {
+    $attachments['#attached']['library'][] = 'rl/experiment-highlight';
+  }
+}
+
+/**
+ * Implements hook_preprocess_html().
+ */
+function rl_preprocess_html(&$variables) {
+  // Add body class on RL admin pages for styling.
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  if ($route_name && str_starts_with($route_name, 'rl.')) {
+    $variables['attributes']['class'][] = 'rl-admin-page';
+  }
+}
+
+/**
  * Implements hook_help().
  */
 function rl_help($route_name, RouteMatchInterface $route_match) {

--- a/rl.routing.yml
+++ b/rl.routing.yml
@@ -50,7 +50,7 @@ rl.reports.experiment_detail:
   path: '/admin/reports/rl/experiment/{experiment_id}'
   defaults:
     _controller: '\Drupal\rl\Controller\ReportsController::experimentDetail'
-    _title: 'Experiment Detail'
+    _title_callback: '\Drupal\rl\Controller\ReportsController::experimentDetailTitle'
   requirements:
     _permission: 'view rl reports'
     experiment_id: '.+'

--- a/src/Controller/ReportsController.php
+++ b/src/Controller/ReportsController.php
@@ -219,6 +219,21 @@ class ReportsController extends ControllerBase {
   }
 
   /**
+   * Title callback for the experiment detail page.
+   *
+   * @param string $experiment_id
+   *   The experiment ID.
+   *
+   * @return string
+   *   The page title.
+   */
+  public function experimentDetailTitle($experiment_id) {
+    $experiment_totals = $this->experimentStorage->getExperimentTotals($experiment_id);
+    $experiment_name = $experiment_totals->experiment_name ?? $experiment_id;
+    return $this->t('Experiment: @name', ['@name' => $experiment_name]);
+  }
+
+  /**
    * Detail page for a specific experiment showing all arms.
    *
    * @param string $experiment_id


### PR DESCRIPTION
## Summary

Add visual branding for RL experiments with an animated gradient border, helping administrators easily identify RL-powered elements.

## Changes

- Add `css/experiment-highlight.css` with animated gradient border
- Add `experiment-highlight` library to `rl.libraries.yml`
- Add `hook_page_attachments()` to attach library for authorized users
- Add `hook_preprocess_html()` to add body class on RL admin pages
- Add `experimentDetailTitle()` callback for dynamic page titles
- Update routing to use title callback

## Color Palette

Uses a 10-color gradient from blue to green to yellow:
- `#0077B6` → `#0096C7` → `#00B4D8` → `#48CAE4` → `#26828E`
- `#1F9E89` → `#35B779` → `#6CCE59` → `#B4DE2C` → `#DAE319`

## Test Plan

- [ ] Log in as user with "view rl reports" permission
- [ ] Visit /admin/reports/rl - verify animated border on page title
- [ ] Visit experiment detail page - verify title shows experiment name
- [ ] Add `rl-experiment` class to any element - verify border appears
- [ ] Log in as user without permission - verify no border styling

Closes #19