### PR TITLE
fix: add Plotly.js installation docs and missing library warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ composer require drupal/rl
 drush en rl
 ```
 
+### Plotly.js Library (Required for Charts)
+
+The RL module uses Plotly.js for experiment charts. Install it via Composer using
+[Asset Packagist](https://asset-packagist.org):
+
+```bash
+# Add Asset Packagist repository (if not already configured)
+composer config repositories.asset-packagist composer https://asset-packagist.org
+
+# Install the Composer plugin for npm assets (if not already installed)
+composer require oomphinc/composer-installers-extender
+composer config extra.installer-types --json '["npm-asset"]'
+composer config extra.installer-paths.web/libraries/\{\$name\} --json '["type:npm-asset"]'
+
+# Install Plotly.js
+composer require npm-asset/plotly.js-dist-min:^2.35
+```
+
+This installs the library to `web/libraries/plotly.js-dist-min/`.
+
 ### Post-Installation: Verify rl.php Access
 
 The RL module includes a `.htaccess` file that allows direct access to

--- a/rl.install
+++ b/rl.install
@@ -435,8 +435,8 @@ function rl_requirements($phase) {
 
   if ($phase == 'runtime') {
     // Check if Plotly.js library is installed.
-    $plotly_path = DRUPAL_ROOT . '/libraries/plotly.js-dist-min/plotly.min.js';
-    if (!file_exists($plotly_path)) {
+    $library_finder = \Drupal::service('library.libraries_directory_file_finder');
+    if (!$library_finder->find('plotly.js-dist-min/plotly.min.js')) {
       $requirements['rl_plotly_library'] = [
         'title' => t('RL: Plotly.js library'),
         'severity' => REQUIREMENT_ERROR,

--- a/src/Controller/ReportsController.php
+++ b/src/Controller/ReportsController.php
@@ -243,6 +243,15 @@ class ReportsController extends ControllerBase {
    *   A render array.
    */
   public function experimentDetail($experiment_id) {
+    // Check if Plotly.js library is installed.
+    $library_finder = \Drupal::service('library.libraries_directory_file_finder');
+    if (!$library_finder->find('plotly.js-dist-min/plotly.min.js')) {
+      $status_url = Url::fromRoute('system.status')->toString();
+      $this->messenger()->addWarning($this->t('Charts require the Plotly.js library. See <a href="@url">Status report</a> for installation instructions.', [
+        '@url' => $status_url,
+      ]));
+    }
+
     // Get experiment totals from storage.
     $experiment_totals = $this->experimentStorage->getExperimentTotals($experiment_id);
 

--- a/src/Controller/ReportsController.php
+++ b/src/Controller/ReportsController.php
@@ -3,6 +3,7 @@
 namespace Drupal\rl\Controller;
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Asset\LibrariesDirectoryFileFinder;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Link;
@@ -71,6 +72,13 @@ class ReportsController extends ControllerBase {
   protected RequestStack $requestStack;
 
   /**
+   * The libraries directory file finder.
+   *
+   * @var \Drupal\Core\Asset\LibrariesDirectoryFileFinder
+   */
+  protected LibrariesDirectoryFileFinder $libraryFinder;
+
+  /**
    * Constructs a ReportsController object.
    *
    * @param \Drupal\rl\Storage\ExperimentDataStorageInterface $experiment_storage
@@ -87,8 +95,10 @@ class ReportsController extends ControllerBase {
    *   The snapshot storage.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request stack.
+   * @param \Drupal\Core\Asset\LibrariesDirectoryFileFinder $library_finder
+   *   The libraries directory file finder.
    */
-  public function __construct(ExperimentDataStorageInterface $experiment_storage, DateFormatterInterface $date_formatter, ExperimentDecoratorManager $decorator_manager, RendererInterface $renderer, ArmDataValidator $arm_data_validator, SnapshotStorageInterface $snapshot_storage, RequestStack $request_stack) {
+  public function __construct(ExperimentDataStorageInterface $experiment_storage, DateFormatterInterface $date_formatter, ExperimentDecoratorManager $decorator_manager, RendererInterface $renderer, ArmDataValidator $arm_data_validator, SnapshotStorageInterface $snapshot_storage, RequestStack $request_stack, LibrariesDirectoryFileFinder $library_finder) {
     $this->experimentStorage = $experiment_storage;
     $this->dateFormatter = $date_formatter;
     $this->decoratorManager = $decorator_manager;
@@ -96,6 +106,7 @@ class ReportsController extends ControllerBase {
     $this->armDataValidator = $arm_data_validator;
     $this->snapshotStorage = $snapshot_storage;
     $this->requestStack = $request_stack;
+    $this->libraryFinder = $library_finder;
   }
 
   /**
@@ -114,7 +125,8 @@ class ReportsController extends ControllerBase {
       $container->get('renderer'),
       $container->get('rl.arm_data_validator'),
       $container->get('rl.snapshot_storage'),
-      $container->get('request_stack')
+      $container->get('request_stack'),
+      $container->get('library.libraries_directory_file_finder')
     );
   }
 
@@ -244,8 +256,7 @@ class ReportsController extends ControllerBase {
    */
   public function experimentDetail($experiment_id) {
     // Check if Plotly.js library is installed.
-    $library_finder = \Drupal::service('library.libraries_directory_file_finder');
-    if (!$library_finder->find('plotly.js-dist-min/plotly.min.js')) {
+    if (!$this->libraryFinder->find('plotly.js-dist-min/plotly.min.js')) {
       $status_url = Url::fromRoute('system.status')->toString();
       $this->messenger()->addWarning($this->t('Charts require the Plotly.js library. See <a href="@url">Status report</a> for installation instructions.', [
         '@url' => $status_url,


### PR DESCRIPTION
## Summary

The status report references the README for Plotly.js installation details, but the documentation was missing. Also, users got a confusing JavaScript error when viewing experiment charts without Plotly installed.

## Changes

**README documentation:**
- Add CLI commands for installing Plotly.js via Asset Packagist

**User experience:**
- Add Drupal messenger warning on experiment detail page when Plotly.js is missing
- Warning links to Status report for installation instructions

**Code quality:**
- Use library.libraries_directory_file_finder service instead of hardcoded path
- Searches multiple locations: sites/{site}/libraries/, libraries/, profiles/{profile}/libraries/

## Test Plan

- [x] Verify README instructions work on a fresh Drupal project
- [x] Confirm Plotly.js installs to web/libraries/plotly.js-dist-min/
- [ ] Without Plotly installed, visit experiment detail page and verify warning message appears
- [ ] Verify warning links to Status report page

Closes #21