### PR TITLE
feat: Content Optimizer module for A/B testing entity text

### DIFF
--- a/modules/content_optimizer/config/install/content_optimizer.settings.yml
+++ b/modules/content_optimizer/config/install/content_optimizer.settings.yml
@@ -1,0 +1,5 @@
+reward_strategy: time_on_page
+reward_threshold: 10
+entity_types:
+  - node
+cache_ttl: 60

--- a/modules/content_optimizer/config/schema/content_optimizer.schema.yml
+++ b/modules/content_optimizer/config/schema/content_optimizer.schema.yml
@@ -1,0 +1,19 @@
+content_optimizer.settings:
+  type: config_object
+  label: 'Content Optimizer settings'
+  mapping:
+    reward_strategy:
+      type: string
+      label: 'Reward strategy'
+    reward_threshold:
+      type: integer
+      label: 'Reward threshold in seconds'
+    entity_types:
+      type: sequence
+      label: 'Enabled entity types'
+      sequence:
+        type: string
+        label: 'Entity type'
+    cache_ttl:
+      type: integer
+      label: 'Cache TTL override in seconds'

--- a/modules/content_optimizer/content_optimizer.info.yml
+++ b/modules/content_optimizer/content_optimizer.info.yml
@@ -1,0 +1,7 @@
+name: 'Content Optimizer'
+type: module
+description: 'A/B test page titles, menu link labels, and other entity text using Thompson Sampling.'
+core_version_requirement: ^10.3 || ^11
+package: RL
+dependencies:
+  - rl:rl

--- a/modules/content_optimizer/content_optimizer.install
+++ b/modules/content_optimizer/content_optimizer.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall functions for Content Optimizer.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function content_optimizer_uninstall() {
+  // Clean up configuration.
+  \Drupal::configFactory()->getEditable('content_optimizer.settings')->delete();
+}

--- a/modules/content_optimizer/content_optimizer.libraries.yml
+++ b/modules/content_optimizer/content_optimizer.libraries.yml
@@ -1,0 +1,20 @@
+title-tracking:
+  js:
+    js/title-tracking.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/once
+
+menu-tracking:
+  js:
+    js/menu-tracking.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - core/once
+
+admin:
+  css:
+    theme:
+      css/content-optimizer.admin.css: {}

--- a/modules/content_optimizer/content_optimizer.links.action.yml
+++ b/modules/content_optimizer/content_optimizer.links.action.yml
@@ -1,0 +1,5 @@
+content_optimizer.experiment.add:
+  title: 'Add experiment'
+  route_name: content_optimizer.experiment.add
+  appears_on:
+    - content_optimizer.experiments

--- a/modules/content_optimizer/content_optimizer.links.menu.yml
+++ b/modules/content_optimizer/content_optimizer.links.menu.yml
@@ -1,0 +1,5 @@
+content_optimizer.experiments:
+  title: 'Content Optimizer'
+  description: 'A/B test page titles, menu links, and other text.'
+  route_name: content_optimizer.experiments
+  parent: system.admin_config_content

--- a/modules/content_optimizer/content_optimizer.links.task.yml
+++ b/modules/content_optimizer/content_optimizer.links.task.yml
@@ -1,0 +1,10 @@
+content_optimizer.experiments:
+  title: 'Experiments'
+  route_name: content_optimizer.experiments
+  base_route: content_optimizer.experiments
+
+content_optimizer.settings:
+  title: 'Settings'
+  route_name: content_optimizer.settings
+  base_route: content_optimizer.experiments
+  weight: 50

--- a/modules/content_optimizer/content_optimizer.module
+++ b/modules/content_optimizer/content_optimizer.module
@@ -1,0 +1,454 @@
+<?php
+
+/**
+ * @file
+ * Content Optimizer module: A/B test page titles and other entity text.
+ */
+
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_help().
+ */
+function content_optimizer_help($route_name, RouteMatchInterface $route_match) {
+  if ($route_name === 'help.page.content_optimizer') {
+    return '<p>' . t('A/B test page titles, menu link labels, and other entity text using Thompson Sampling. Add variant texts on entity edit forms or via the admin UI, and the module automatically tests which performs best.') . '</p>';
+  }
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function content_optimizer_entity_extra_field_info() {
+  $extra = [];
+  $config = \Drupal::config('content_optimizer.settings');
+  $entity_types = $config->get('entity_types') ?? ['node'];
+
+  foreach ($entity_types as $entity_type_id) {
+    $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id, FALSE);
+    if (!$entity_type) {
+      continue;
+    }
+
+    $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($entity_type_id);
+    foreach (array_keys($bundles) as $bundle) {
+      $extra[$entity_type_id][$bundle]['form']['content_optimizer'] = [
+        'label' => t('Title variants'),
+        'description' => t('Content Optimizer variant editor.'),
+        'weight' => 50,
+        'visible' => TRUE,
+      ];
+    }
+  }
+
+  return $extra;
+}
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Adds the title variants vertical tab to entity edit forms for supported
+ * entity types.
+ */
+function content_optimizer_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  $form_object = $form_state->getFormObject();
+  if (!($form_object instanceof \Drupal\Core\Entity\ContentEntityFormInterface)) {
+    return;
+  }
+
+  $entity = $form_object->getEntity();
+  if (!$entity || $entity->isNew()) {
+    return;
+  }
+
+  $entity_type_id = $entity->getEntityTypeId();
+  $config = \Drupal::config('content_optimizer.settings');
+  $enabled_types = $config->get('entity_types') ?? ['node'];
+
+  if (!in_array($entity_type_id, $enabled_types)) {
+    return;
+  }
+
+  // Only alter the default/edit form operations.
+  $operation = $form_object->getOperation();
+  if (!in_array($operation, ['default', 'edit'])) {
+    return;
+  }
+
+  // Load existing experiment for this entity's title.
+  $experiments = \Drupal::entityTypeManager()
+    ->getStorage('content_optimizer_experiment')
+    ->loadByProperties([
+      'target_entity_type' => $entity_type_id,
+      'target_entity_id' => $entity->id(),
+      'target_field' => 'title',
+    ]);
+  $experiment = $experiments ? reset($experiments) : NULL;
+  $existing_variants = $experiment ? $experiment->getVariants() : [];
+
+  // Build the vertical tab.
+  $form['content_optimizer'] = [
+    '#type' => 'details',
+    '#title' => t('Title variants'),
+    '#group' => 'advanced',
+    '#open' => FALSE,
+    '#weight' => 50,
+    '#tree' => TRUE,
+    '#attached' => [
+      'library' => ['content_optimizer/admin'],
+    ],
+  ];
+
+  // Show experiment status if active.
+  if ($experiment && $experiment->isPublished()) {
+    $rl_experiment_id = $experiment->getRlExperimentId();
+    $experiment_manager = \Drupal::service('rl.experiment_manager');
+    $total_turns = $experiment_manager->getTotalTurns($rl_experiment_id);
+    $variant_count = count($existing_variants) + 1;
+
+    $status_text = t('@count variants, @impressions impressions', [
+      '@count' => $variant_count,
+      '@impressions' => $total_turns,
+    ]);
+
+    $report_url = Url::fromRoute('rl.reports.experiment_detail', [
+      'experiment_id' => $rl_experiment_id,
+    ]);
+
+    $form['content_optimizer']['status'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['content-optimizer-status']],
+      'text' => [
+        '#markup' => '<strong>' . t('Active') . '</strong> &mdash; ' . $status_text . ' ',
+      ],
+      'link' => [
+        '#type' => 'link',
+        '#title' => t('View report'),
+        '#url' => $report_url,
+        '#attributes' => ['target' => '_blank'],
+      ],
+    ];
+  }
+
+  $form['content_optimizer']['description'] = [
+    '#markup' => '<p>' . t('Add alternative titles to test which performs best. The original title is always included as a variant.') . '</p>',
+  ];
+
+  // Variant text fields.
+  $num_variants = $form_state->get('co_num_variants');
+  if ($num_variants === NULL) {
+    $num_variants = max(1, count($existing_variants));
+    $form_state->set('co_num_variants', $num_variants);
+  }
+
+  $form['content_optimizer']['variants'] = [
+    '#type' => 'container',
+    '#prefix' => '<div id="content-optimizer-variants-wrapper">',
+    '#suffix' => '</div>',
+  ];
+
+  for ($i = 0; $i < $num_variants; $i++) {
+    $form['content_optimizer']['variants'][$i] = [
+      '#type' => 'textfield',
+      '#title' => t('Variant @num', ['@num' => $i + 1]),
+      '#default_value' => $existing_variants[$i] ?? '',
+      '#maxlength' => 512,
+    ];
+  }
+
+  $form['content_optimizer']['variants']['add_variant'] = [
+    '#type' => 'submit',
+    '#value' => t('Add variant'),
+    '#name' => 'co_add_variant',
+    '#submit' => ['_content_optimizer_add_variant_submit'],
+    '#ajax' => [
+      'callback' => '_content_optimizer_variants_ajax',
+      'wrapper' => 'content-optimizer-variants-wrapper',
+    ],
+    '#limit_validation_errors' => [],
+  ];
+
+  if ($num_variants > 1) {
+    $form['content_optimizer']['variants']['remove_variant'] = [
+      '#type' => 'submit',
+      '#value' => t('Remove last'),
+      '#name' => 'co_remove_variant',
+      '#submit' => ['_content_optimizer_remove_variant_submit'],
+      '#ajax' => [
+        'callback' => '_content_optimizer_variants_ajax',
+        'wrapper' => 'content-optimizer-variants-wrapper',
+      ],
+      '#limit_validation_errors' => [],
+    ];
+  }
+
+  $form['content_optimizer']['enabled'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Enable experiment'),
+    '#default_value' => $experiment ? $experiment->isPublished() : TRUE,
+  ];
+
+  if ($experiment) {
+    $form['content_optimizer']['experiment_id'] = [
+      '#type' => 'value',
+      '#value' => $experiment->id(),
+    ];
+  }
+
+  // Add our submit handler.
+  $form['actions']['submit']['#submit'][] = '_content_optimizer_entity_form_submit';
+}
+
+/**
+ * AJAX callback for variants section.
+ */
+function _content_optimizer_variants_ajax(array &$form, FormStateInterface $form_state) {
+  return $form['content_optimizer']['variants'];
+}
+
+/**
+ * Submit handler: add a variant row.
+ */
+function _content_optimizer_add_variant_submit(array &$form, FormStateInterface $form_state) {
+  $num = $form_state->get('co_num_variants') ?? 1;
+  $form_state->set('co_num_variants', $num + 1);
+  $form_state->setRebuild();
+}
+
+/**
+ * Submit handler: remove the last variant row.
+ */
+function _content_optimizer_remove_variant_submit(array &$form, FormStateInterface $form_state) {
+  $num = $form_state->get('co_num_variants') ?? 1;
+  if ($num > 1) {
+    $form_state->set('co_num_variants', $num - 1);
+  }
+  $form_state->setRebuild();
+}
+
+/**
+ * Submit handler: save the experiment when the entity form is saved.
+ */
+function _content_optimizer_entity_form_submit(array &$form, FormStateInterface $form_state) {
+  $form_object = $form_state->getFormObject();
+  $entity = $form_object->getEntity();
+  $co_values = $form_state->getValue('content_optimizer');
+
+  if (empty($co_values)) {
+    return;
+  }
+
+  // Collect variant texts.
+  $variants = [];
+  if (!empty($co_values['variants'])) {
+    foreach ($co_values['variants'] as $key => $value) {
+      if (is_numeric($key) && is_string($value) && !empty(trim($value))) {
+        $variants[] = trim($value);
+      }
+    }
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('content_optimizer_experiment');
+
+  // Load existing or create new experiment.
+  $experiment_id = $co_values['experiment_id'] ?? NULL;
+  if ($experiment_id) {
+    $experiment = $storage->load($experiment_id);
+  }
+  else {
+    $experiment = NULL;
+  }
+
+  if (empty($variants)) {
+    // No variants: delete experiment if it exists.
+    if ($experiment) {
+      $experiment->delete();
+      \Drupal::messenger()->addStatus(t('Title experiment removed.'));
+    }
+    return;
+  }
+
+  if (!$experiment) {
+    $experiment = $storage->create([
+      'target_entity_type' => $entity->getEntityTypeId(),
+      'target_entity_id' => $entity->id(),
+      'target_field' => 'title',
+    ]);
+  }
+
+  $experiment->setVariants($variants);
+
+  if (!empty($co_values['enabled'])) {
+    $experiment->setPublished();
+  }
+  else {
+    $experiment->setUnpublished();
+  }
+
+  $experiment->save();
+
+  // Register with RL.
+  \Drupal::service('content_optimizer.experiment_registration')->register(
+    $experiment->getRlExperimentId(),
+    $experiment->getExperimentLabel()
+  );
+}
+
+/**
+ * Implements hook_preprocess_page_title().
+ *
+ * Overrides the visible page title with the winning variant.
+ */
+function content_optimizer_preprocess_page_title(array &$variables) {
+  $result = _content_optimizer_get_active_variant();
+  if ($result && $result['text'] !== NULL) {
+    $variables['title'] = $result['text'];
+  }
+}
+
+/**
+ * Implements hook_preprocess_html().
+ *
+ * Overrides the <title> tag with the winning variant.
+ */
+function content_optimizer_preprocess_html(array &$variables) {
+  $result = _content_optimizer_get_active_variant();
+  if ($result && $result['text'] !== NULL && isset($variables['head_title']['title'])) {
+    $variables['head_title']['title'] = $result['text'];
+  }
+}
+
+/**
+ * Implements hook_page_attachments().
+ *
+ * Attaches tracking JavaScript when a variant experiment is active.
+ */
+function content_optimizer_page_attachments(array &$attachments) {
+  $result = _content_optimizer_get_active_variant();
+  if (!$result) {
+    return;
+  }
+
+  $config = \Drupal::config('content_optimizer.settings');
+  $rl_path = \Drupal::service('extension.list.module')->getPath('rl');
+  $base_path = \Drupal::request()->getBasePath();
+
+  $attachments['#attached']['library'][] = 'content_optimizer/title-tracking';
+  $attachments['#attached']['drupalSettings']['contentOptimizer'] = [
+    'experimentId' => $result['experiment_id'],
+    'armId' => $result['arm_id'],
+    'rlEndpointUrl' => $base_path . '/' . $rl_path . '/rl.php',
+    'rewardStrategy' => $config->get('reward_strategy') ?? 'time_on_page',
+    'rewardThreshold' => ($config->get('reward_threshold') ?? 10) * 1000,
+  ];
+}
+
+/**
+ * Implements hook_entity_delete().
+ *
+ * Cleans up experiments when the target entity is deleted.
+ */
+function content_optimizer_entity_delete(EntityInterface $entity) {
+  $experiments = \Drupal::entityTypeManager()
+    ->getStorage('content_optimizer_experiment')
+    ->loadByProperties([
+      'target_entity_type' => $entity->getEntityTypeId(),
+      'target_entity_id' => $entity->id(),
+    ]);
+
+  foreach ($experiments as $experiment) {
+    $experiment->delete();
+  }
+}
+
+/**
+ * Get the active variant for the current page.
+ *
+ * Results are statically cached per request.
+ *
+ * @return array|null
+ *   Variant selection result or NULL.
+ */
+function _content_optimizer_get_active_variant(): ?array {
+  $result = &drupal_static(__FUNCTION__);
+  if ($result !== NULL) {
+    // Return cached result; FALSE means "checked, no variant".
+    return $result === FALSE ? NULL : $result;
+  }
+
+  $route_match = \Drupal::routeMatch();
+  $config = \Drupal::config('content_optimizer.settings');
+  $enabled_types = $config->get('entity_types') ?? ['node'];
+
+  // Try to find an entity parameter in the route.
+  foreach ($enabled_types as $entity_type_id) {
+    $entity = $route_match->getParameter($entity_type_id);
+    if ($entity instanceof \Drupal\Core\Entity\ContentEntityInterface) {
+      /** @var \Drupal\content_optimizer\Service\VariantSelector $selector */
+      $selector = \Drupal::service('content_optimizer.variant_selector');
+      $selection = $selector->selectVariant($entity_type_id, (int) $entity->id(), 'title');
+      if ($selection) {
+        $result = $selection;
+        return $result;
+      }
+    }
+  }
+
+  $result = FALSE;
+  return NULL;
+}
+
+/**
+ * Implements hook_preprocess_menu().
+ *
+ * Overrides menu link labels with winning variants.
+ */
+function content_optimizer_preprocess_menu(array &$variables) {
+  if (empty($variables['items'])) {
+    return;
+  }
+
+  _content_optimizer_process_menu_items($variables['items']);
+}
+
+/**
+ * Recursively process menu items for variant selection.
+ *
+ * @param array &$items
+ *   Menu items to process.
+ */
+function _content_optimizer_process_menu_items(array &$items) {
+  /** @var \Drupal\content_optimizer\Service\VariantSelector $selector */
+  $selector = \Drupal::service('content_optimizer.variant_selector');
+  $menu_tracking = &drupal_static('content_optimizer_menu_tracking', []);
+
+  foreach ($items as &$item) {
+    // Check if this menu item links to an entity.
+    if (isset($item['url']) && $item['url'] instanceof Url) {
+      $route_params = $item['url']->getRouteParameters();
+      if (!empty($route_params)) {
+        foreach ($route_params as $entity_type => $entity_id) {
+          $result = $selector->selectVariant($entity_type, (int) $entity_id, 'menu_link_label');
+          if ($result && $result['text'] !== NULL) {
+            $item['title'] = $result['text'];
+            $menu_tracking[] = [
+              'experimentId' => $result['experiment_id'],
+              'armId' => $result['arm_id'],
+              'entityId' => $entity_id,
+            ];
+          }
+          break;
+        }
+      }
+    }
+
+    // Process children recursively.
+    if (!empty($item['below'])) {
+      _content_optimizer_process_menu_items($item['below']);
+    }
+  }
+}

--- a/modules/content_optimizer/content_optimizer.module
+++ b/modules/content_optimizer/content_optimizer.module
@@ -5,7 +5,8 @@
  * Content Optimizer module: A/B test page titles and other entity text.
  */
 
-use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\ContentEntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -56,7 +57,7 @@ function content_optimizer_entity_extra_field_info() {
  */
 function content_optimizer_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   $form_object = $form_state->getFormObject();
-  if (!($form_object instanceof \Drupal\Core\Entity\ContentEntityFormInterface)) {
+  if (!($form_object instanceof ContentEntityFormInterface)) {
     return;
   }
 
@@ -387,7 +388,7 @@ function _content_optimizer_get_active_variant(): ?array {
   // Try to find an entity parameter in the route.
   foreach ($enabled_types as $entity_type_id) {
     $entity = $route_match->getParameter($entity_type_id);
-    if ($entity instanceof \Drupal\Core\Entity\ContentEntityInterface) {
+    if ($entity instanceof ContentEntityInterface) {
       /** @var \Drupal\content_optimizer\Service\VariantSelector $selector */
       $selector = \Drupal::service('content_optimizer.variant_selector');
       $selection = $selector->selectVariant($entity_type_id, (int) $entity->id(), 'title');

--- a/modules/content_optimizer/content_optimizer.permissions.yml
+++ b/modules/content_optimizer/content_optimizer.permissions.yml
@@ -1,0 +1,4 @@
+administer content optimizer:
+  title: 'Administer Content Optimizer'
+  description: 'Create, edit, and delete content optimization experiments.'
+  restrict access: true

--- a/modules/content_optimizer/content_optimizer.routing.yml
+++ b/modules/content_optimizer/content_optimizer.routing.yml
@@ -1,0 +1,39 @@
+content_optimizer.experiments:
+  path: '/admin/config/content/content-optimizer'
+  defaults:
+    _entity_list: 'content_optimizer_experiment'
+    _title: 'Content Optimizer'
+  requirements:
+    _permission: 'administer content optimizer'
+
+content_optimizer.experiment.add:
+  path: '/admin/config/content/content-optimizer/add'
+  defaults:
+    _entity_form: 'content_optimizer_experiment.add'
+    _title: 'Add Experiment'
+  requirements:
+    _permission: 'administer content optimizer'
+
+content_optimizer.experiment.edit:
+  path: '/admin/config/content/content-optimizer/{content_optimizer_experiment}/edit'
+  defaults:
+    _entity_form: 'content_optimizer_experiment.edit'
+    _title: 'Edit Experiment'
+  requirements:
+    _permission: 'administer content optimizer'
+
+content_optimizer.experiment.delete:
+  path: '/admin/config/content/content-optimizer/{content_optimizer_experiment}/delete'
+  defaults:
+    _entity_form: 'content_optimizer_experiment.delete'
+    _title: 'Delete Experiment'
+  requirements:
+    _permission: 'administer content optimizer'
+
+content_optimizer.settings:
+  path: '/admin/config/content/content-optimizer/settings'
+  defaults:
+    _form: '\Drupal\content_optimizer\Form\SettingsForm'
+    _title: 'Content Optimizer Settings'
+  requirements:
+    _permission: 'administer site configuration'

--- a/modules/content_optimizer/content_optimizer.services.yml
+++ b/modules/content_optimizer/content_optimizer.services.yml
@@ -1,0 +1,14 @@
+services:
+  content_optimizer.experiment_registration:
+    class: Drupal\content_optimizer\Service\ExperimentRegistrationService
+    arguments: ['@rl.experiment_registry']
+
+  content_optimizer.variant_selector:
+    class: Drupal\content_optimizer\Service\VariantSelector
+    arguments: ['@rl.experiment_manager', '@entity_type.manager', '@rl.cache_manager']
+
+  content_optimizer.experiment_decorator:
+    class: Drupal\content_optimizer\Decorator\ContentOptimizerDecorator
+    arguments: ['@entity_type.manager']
+    tags:
+      - { name: rl_experiment_decorator }

--- a/modules/content_optimizer/css/content-optimizer.admin.css
+++ b/modules/content_optimizer/css/content-optimizer.admin.css
@@ -1,0 +1,16 @@
+/**
+ * @file
+ * Admin styles for Content Optimizer.
+ */
+
+.content-optimizer-status {
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background: #f0f8f0;
+  border-left: 3px solid #4caf50;
+  border-radius: 2px;
+}
+
+.content-optimizer-status a {
+  font-weight: bold;
+}

--- a/modules/content_optimizer/js/menu-tracking.js
+++ b/modules/content_optimizer/js/menu-tracking.js
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * Client-side tracking for Content Optimizer menu link experiments.
+ *
+ * Uses IntersectionObserver for impressions and click listeners for rewards,
+ * following the same pattern as ai_sorting.
+ */
+
+(function (Drupal, drupalSettings, once) {
+
+  'use strict';
+
+  Drupal.behaviors.contentOptimizerMenuTracking = {
+    attach: function (context) {
+      if (!drupalSettings.contentOptimizerMenu || !drupalSettings.contentOptimizerMenu.experiments) {
+        return;
+      }
+
+      var experiments = drupalSettings.contentOptimizerMenu.experiments;
+      var endpointUrl = drupalSettings.contentOptimizerMenu.rlEndpointUrl;
+
+      once('content-optimizer-menu', 'nav a, .menu a', context).forEach(function (link) {
+        var href = link.getAttribute('href');
+        if (!href) {
+          return;
+        }
+
+        // Find matching experiment for this link.
+        var matched = null;
+        for (var i = 0; i < experiments.length; i++) {
+          var exp = experiments[i];
+          if (href.indexOf('/node/' + exp.entityId) !== -1 ||
+              href.indexOf('/' + exp.entityId) !== -1) {
+            matched = exp;
+            break;
+          }
+        }
+
+        if (!matched) {
+          return;
+        }
+
+        // Turn tracking via IntersectionObserver.
+        var turnObserver = new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting && !entry.target.dataset.coTracked) {
+              entry.target.dataset.coTracked = '1';
+              var turnData = new FormData();
+              turnData.append('action', 'turn');
+              turnData.append('experiment_id', matched.experimentId);
+              turnData.append('arm_id', matched.armId);
+              navigator.sendBeacon(endpointUrl, turnData);
+            }
+          });
+        }, { threshold: 0.1 });
+
+        turnObserver.observe(link);
+
+        // Reward tracking on click.
+        link.addEventListener('click', function () {
+          var rewardKey = 'co-menu-reward-' + matched.experimentId;
+          if (!sessionStorage.getItem(rewardKey)) {
+            sessionStorage.setItem(rewardKey, '1');
+            var rewardData = new FormData();
+            rewardData.append('action', 'reward');
+            rewardData.append('experiment_id', matched.experimentId);
+            rewardData.append('arm_id', matched.armId);
+            navigator.sendBeacon(endpointUrl, rewardData);
+          }
+        });
+      });
+    }
+  };
+
+})(Drupal, drupalSettings, once);

--- a/modules/content_optimizer/js/title-tracking.js
+++ b/modules/content_optimizer/js/title-tracking.js
@@ -1,0 +1,79 @@
+/**
+ * @file
+ * Client-side tracking for Content Optimizer page title experiments.
+ *
+ * Records a turn (impression) on page load, and a reward based on the
+ * configured strategy (time on page, scroll depth, or next click).
+ */
+
+(function (Drupal, drupalSettings, once) {
+
+  'use strict';
+
+  Drupal.behaviors.contentOptimizerTitleTracking = {
+    attach: function (context) {
+      if (!drupalSettings.contentOptimizer) {
+        return;
+      }
+
+      once('content-optimizer-title', 'body', context).forEach(function () {
+        var settings = drupalSettings.contentOptimizer;
+        var experimentId = settings.experimentId;
+        var armId = settings.armId;
+        var endpointUrl = settings.rlEndpointUrl;
+        var strategy = settings.rewardStrategy || 'time_on_page';
+        var threshold = settings.rewardThreshold || 10000;
+
+        // Record turn (impression): this variant was shown.
+        var turnData = new FormData();
+        turnData.append('action', 'turn');
+        turnData.append('experiment_id', experimentId);
+        turnData.append('arm_id', armId);
+        navigator.sendBeacon(endpointUrl, turnData);
+
+        // Reward tracking based on strategy.
+        var rewardKey = 'co-reward-' + experimentId;
+
+        function sendReward() {
+          if (sessionStorage.getItem(rewardKey)) {
+            return;
+          }
+          sessionStorage.setItem(rewardKey, '1');
+          var rewardData = new FormData();
+          rewardData.append('action', 'reward');
+          rewardData.append('experiment_id', experimentId);
+          rewardData.append('arm_id', armId);
+          navigator.sendBeacon(endpointUrl, rewardData);
+        }
+
+        if (strategy === 'time_on_page') {
+          // Reward if user stays for the configured threshold.
+          setTimeout(sendReward, threshold);
+        }
+        else if (strategy === 'scroll_depth') {
+          // Reward if user scrolls past 50% of the page.
+          var scrollHandler = function () {
+            var scrollPercent = (window.scrollY + window.innerHeight) / document.documentElement.scrollHeight;
+            if (scrollPercent >= 0.5) {
+              sendReward();
+              window.removeEventListener('scroll', scrollHandler);
+            }
+          };
+          window.addEventListener('scroll', scrollHandler, { passive: true });
+        }
+        else if (strategy === 'next_click') {
+          // Reward on any link click on the page.
+          var clickHandler = function (e) {
+            var link = e.target.closest('a');
+            if (link && link.href) {
+              sendReward();
+              document.removeEventListener('click', clickHandler);
+            }
+          };
+          document.addEventListener('click', clickHandler);
+        }
+      });
+    }
+  };
+
+})(Drupal, drupalSettings, once);

--- a/modules/content_optimizer/src/Decorator/ContentOptimizerDecorator.php
+++ b/modules/content_optimizer/src/Decorator/ContentOptimizerDecorator.php
@@ -89,7 +89,7 @@ class ContentOptimizerDecorator implements ExperimentDecoratorInterface {
    *   The experiment entity or NULL.
    */
   protected function findExperimentByRlId(string $rl_experiment_id) {
-    // Parse experiment ID: content_optimizer-{type}-{id}-{field}
+    // Parse experiment ID: content_optimizer-{type}-{id}-{field}.
     $parts = explode('-', $rl_experiment_id, 4);
     if (count($parts) < 4 || $parts[0] !== 'content_optimizer') {
       return NULL;

--- a/modules/content_optimizer/src/Decorator/ContentOptimizerDecorator.php
+++ b/modules/content_optimizer/src/Decorator/ContentOptimizerDecorator.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\content_optimizer\Decorator;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\rl\Decorator\ExperimentDecoratorInterface;
+
+/**
+ * Decorates RL reports with human-readable variant text.
+ */
+class ContentOptimizerDecorator implements ExperimentDecoratorInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Constructs a ContentOptimizerDecorator.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function decorateExperiment(string $experiment_id): ?array {
+    if (!str_starts_with($experiment_id, 'content_optimizer-')) {
+      return NULL;
+    }
+
+    // Load the experiment entity and return a label.
+    $experiment = $this->findExperimentByRlId($experiment_id);
+    if (!$experiment) {
+      return NULL;
+    }
+
+    return ['#markup' => Html::escape($experiment->getExperimentLabel())];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function decorateArm(string $experiment_id, string $arm_id): ?array {
+    if (!str_starts_with($experiment_id, 'content_optimizer-')) {
+      return NULL;
+    }
+
+    $experiment = $this->findExperimentByRlId($experiment_id);
+    if (!$experiment) {
+      return NULL;
+    }
+
+    if ($arm_id === 'v0') {
+      // Load the original entity field value.
+      $entity_id = $experiment->get('target_entity_id')->value;
+      $entity_type = $experiment->get('target_entity_type')->value;
+      $field = $experiment->get('target_field')->value;
+      $entity = $this->entityTypeManager->getStorage($entity_type)->load($entity_id);
+      if ($entity) {
+        $label = $entity->label();
+        return ['#markup' => Html::escape($label) . ' <small>(original)</small>'];
+      }
+      return ['#markup' => '<em>original</em>'];
+    }
+
+    $text = $experiment->getArmText($arm_id);
+    if ($text !== NULL) {
+      return ['#markup' => Html::escape($text)];
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Find a content_optimizer_experiment entity by its RL experiment ID.
+   *
+   * @param string $rl_experiment_id
+   *   The RL experiment ID.
+   *
+   * @return \Drupal\content_optimizer\Entity\Experiment|null
+   *   The experiment entity or NULL.
+   */
+  protected function findExperimentByRlId(string $rl_experiment_id) {
+    // Parse experiment ID: content_optimizer-{type}-{id}-{field}
+    $parts = explode('-', $rl_experiment_id, 4);
+    if (count($parts) < 4 || $parts[0] !== 'content_optimizer') {
+      return NULL;
+    }
+
+    $target_type = $parts[1];
+
+    if ($target_type === 'path') {
+      // Path-based experiments: look up by path.
+      return NULL;
+    }
+
+    $target_id = $parts[2];
+    $target_field = $parts[3];
+
+    $experiments = $this->entityTypeManager
+      ->getStorage('content_optimizer_experiment')
+      ->loadByProperties([
+        'target_entity_type' => $target_type,
+        'target_entity_id' => $target_id,
+        'target_field' => $target_field,
+      ]);
+
+    return $experiments ? reset($experiments) : NULL;
+  }
+
+}

--- a/modules/content_optimizer/src/Entity/Experiment.php
+++ b/modules/content_optimizer/src/Entity/Experiment.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Drupal\content_optimizer\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityPublishedTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Defines the Content Optimizer Experiment entity.
+ *
+ * @ContentEntityType(
+ *   id = "content_optimizer_experiment",
+ *   label = @Translation("Content Optimizer Experiment"),
+ *   label_collection = @Translation("Content Optimizer Experiments"),
+ *   label_singular = @Translation("experiment"),
+ *   label_plural = @Translation("experiments"),
+ *   handlers = {
+ *     "form" = {
+ *       "default" = "Drupal\content_optimizer\Form\ExperimentForm",
+ *       "add" = "Drupal\content_optimizer\Form\ExperimentForm",
+ *       "edit" = "Drupal\content_optimizer\Form\ExperimentForm",
+ *       "delete" = "Drupal\content_optimizer\Form\ExperimentDeleteForm",
+ *     },
+ *     "list_builder" = "Drupal\content_optimizer\ExperimentListBuilder",
+ *     "access" = "Drupal\content_optimizer\ExperimentAccessControlHandler",
+ *   },
+ *   base_table = "content_optimizer_experiment",
+ *   admin_permission = "administer content optimizer",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "uuid" = "uuid",
+ *     "langcode" = "langcode",
+ *     "published" = "enabled",
+ *   },
+ *   links = {
+ *     "add-form" = "/admin/config/content/content-optimizer/add",
+ *     "edit-form" = "/admin/config/content/content-optimizer/{content_optimizer_experiment}/edit",
+ *     "delete-form" = "/admin/config/content/content-optimizer/{content_optimizer_experiment}/delete",
+ *     "collection" = "/admin/config/content/content-optimizer",
+ *   },
+ * )
+ */
+class Experiment extends ContentEntityBase {
+
+  use EntityPublishedTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+    $fields += static::publishedBaseFieldDefinitions($entity_type);
+
+    $fields['target_entity_type'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Target entity type'))
+      ->setRequired(TRUE)
+      ->setSetting('max_length', 64)
+      ->setDefaultValue('node');
+
+    $fields['target_entity_id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Target entity ID'))
+      ->setSetting('unsigned', TRUE);
+
+    $fields['target_field'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Target field'))
+      ->setRequired(TRUE)
+      ->setSetting('max_length', 64)
+      ->setDefaultValue('title');
+
+    $fields['target_path'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Target path'))
+      ->setDescription(t('For non-entity experiments, the page path.'))
+      ->setSetting('max_length', 2048);
+
+    $fields['variants_data'] = BaseFieldDefinition::create('string_long')
+      ->setLabel(t('Variants'))
+      ->setDescription(t('JSON-encoded variant texts.'));
+
+    $fields['uid'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('Author'))
+      ->setSetting('target_type', 'user')
+      ->setDefaultValueCallback(static::class . '::getDefaultEntityOwner');
+
+    $fields['created'] = BaseFieldDefinition::create('created')
+      ->setLabel(t('Created'));
+
+    return $fields;
+  }
+
+  /**
+   * Default value callback for the uid field.
+   */
+  public static function getDefaultEntityOwner() {
+    return [\Drupal::currentUser()->id()];
+  }
+
+  /**
+   * Get the RL experiment ID for this experiment.
+   *
+   * @return string
+   *   Deterministic experiment ID.
+   */
+  public function getRlExperimentId(): string {
+    $entity_id = $this->get('target_entity_id')->value;
+    if ($entity_id) {
+      return 'content_optimizer-' . $this->get('target_entity_type')->value . '-' . $entity_id . '-' . $this->get('target_field')->value;
+    }
+    // Path-based experiment.
+    $path = $this->get('target_path')->value;
+    $path_safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', trim($path, '/'));
+    return 'content_optimizer-path-' . $path_safe . '-' . $this->get('target_field')->value;
+  }
+
+  /**
+   * Get the variant texts.
+   *
+   * @return string[]
+   *   Array of variant text strings.
+   */
+  public function getVariants(): array {
+    $data = $this->get('variants_data')->value;
+    if (empty($data)) {
+      return [];
+    }
+    $decoded = json_decode($data, TRUE);
+    return is_array($decoded) ? $decoded : [];
+  }
+
+  /**
+   * Set the variant texts.
+   *
+   * @param string[] $variants
+   *   Array of variant text strings.
+   *
+   * @return $this
+   */
+  public function setVariants(array $variants): static {
+    $this->set('variants_data', json_encode(array_values($variants)));
+    return $this;
+  }
+
+  /**
+   * Get a human-readable label for this experiment.
+   *
+   * @return string
+   *   Label like "node 42 title" or "path /about title".
+   */
+  public function getExperimentLabel(): string {
+    $entity_id = $this->get('target_entity_id')->value;
+    $field = $this->get('target_field')->value;
+    if ($entity_id) {
+      $type = $this->get('target_entity_type')->value;
+      $entity = \Drupal::entityTypeManager()->getStorage($type)->load($entity_id);
+      $entity_label = $entity ? $entity->label() : "$type $entity_id";
+      return "$entity_label ($field)";
+    }
+    $path = $this->get('target_path')->value;
+    return "$path ($field)";
+  }
+
+  /**
+   * Build the arm IDs for this experiment.
+   *
+   * @return string[]
+   *   Array of arm IDs: v0 for original, v1-vN for variants.
+   */
+  public function getArmIds(): array {
+    $arm_ids = ['v0'];
+    $variants = $this->getVariants();
+    for ($i = 0; $i < count($variants); $i++) {
+      $arm_ids[] = 'v' . ($i + 1);
+    }
+    return $arm_ids;
+  }
+
+  /**
+   * Get the text for a specific arm ID.
+   *
+   * @param string $arm_id
+   *   Arm ID like "v0", "v1", etc.
+   *
+   * @return string|null
+   *   The variant text, or NULL for v0 (use original).
+   */
+  public function getArmText(string $arm_id): ?string {
+    if ($arm_id === 'v0') {
+      return NULL;
+    }
+    $index = (int) substr($arm_id, 1) - 1;
+    $variants = $this->getVariants();
+    return $variants[$index] ?? NULL;
+  }
+
+}

--- a/modules/content_optimizer/src/ExperimentAccessControlHandler.php
+++ b/modules/content_optimizer/src/ExperimentAccessControlHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\content_optimizer;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access control handler for Content Optimizer Experiment entities.
+ */
+class ExperimentAccessControlHandler extends EntityAccessControlHandler {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
+    return AccessResult::allowedIfHasPermission($account, 'administer content optimizer');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
+    return AccessResult::allowedIfHasPermission($account, 'administer content optimizer');
+  }
+
+}

--- a/modules/content_optimizer/src/ExperimentListBuilder.php
+++ b/modules/content_optimizer/src/ExperimentListBuilder.php
@@ -4,9 +4,7 @@ namespace Drupal\content_optimizer;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\rl\Service\ExperimentManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/modules/content_optimizer/src/ExperimentListBuilder.php
+++ b/modules/content_optimizer/src/ExperimentListBuilder.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\content_optimizer;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\rl\Service\ExperimentManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * List builder for Content Optimizer Experiment entities.
+ */
+class ExperimentListBuilder extends EntityListBuilder {
+
+  /**
+   * The RL experiment manager.
+   *
+   * @var \Drupal\rl\Service\ExperimentManagerInterface
+   */
+  protected ExperimentManagerInterface $experimentManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    $instance = parent::createInstance($container, $entity_type);
+    $instance->experimentManager = $container->get('rl.experiment_manager');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['target'] = $this->t('Target');
+    $header['field'] = $this->t('Field');
+    $header['variants'] = $this->t('Variants');
+    $header['impressions'] = $this->t('Impressions');
+    $header['leader'] = $this->t('Leader');
+    $header['score'] = $this->t('Conv. Score');
+    $header['status'] = $this->t('Status');
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\content_optimizer\Entity\Experiment $entity */
+    $row['target'] = $entity->getExperimentLabel();
+    $row['field'] = $entity->get('target_field')->value;
+
+    $variants = $entity->getVariants();
+    // +1 for original.
+    $row['variants'] = count($variants) + 1;
+
+    $rl_experiment_id = $entity->getRlExperimentId();
+    $arms_data = $this->experimentManager->getAllArmsData($rl_experiment_id);
+    $total_turns = $this->experimentManager->getTotalTurns($rl_experiment_id);
+
+    $row['impressions'] = $total_turns;
+
+    // Find the leading arm.
+    if (!empty($arms_data)) {
+      $best_arm = NULL;
+      $best_score = -1;
+      foreach ($arms_data as $arm) {
+        $alpha = $arm->rewards + 1;
+        $beta = max(1, $arm->turns - $arm->rewards + 1);
+        $score = $alpha / ($alpha + $beta);
+        if ($score > $best_score) {
+          $best_score = $score;
+          $best_arm = $arm;
+        }
+      }
+      if ($best_arm && $total_turns > 0) {
+        $arm_text = $entity->getArmText($best_arm->arm_id);
+        $row['leader'] = $arm_text ?? $this->t('(original)');
+        $row['score'] = number_format($best_score * 100, 1) . '%';
+      }
+      else {
+        $row['leader'] = $this->t('(no data)');
+        $row['score'] = '--';
+      }
+    }
+    else {
+      $row['leader'] = $this->t('(no data)');
+      $row['score'] = '--';
+    }
+
+    $row['status'] = $entity->isPublished() ? $this->t('Active') : $this->t('Disabled');
+
+    return $row + parent::buildRow($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultOperations(EntityInterface $entity) {
+    $operations = parent::getDefaultOperations($entity);
+
+    /** @var \Drupal\content_optimizer\Entity\Experiment $entity */
+    $rl_experiment_id = $entity->getRlExperimentId();
+    $operations['view_report'] = [
+      'title' => $this->t('Report'),
+      'url' => Url::fromRoute('rl.reports.experiment_detail', [
+        'experiment_id' => $rl_experiment_id,
+      ]),
+      'weight' => 20,
+    ];
+
+    return $operations;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build = parent::render();
+    $build['#empty'] = $this->t('No experiments yet. Create one to start A/B testing content.');
+    return $build;
+  }
+
+}

--- a/modules/content_optimizer/src/Form/ExperimentDeleteForm.php
+++ b/modules/content_optimizer/src/Form/ExperimentDeleteForm.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\content_optimizer\Form;
+
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Confirmation form for deleting a Content Optimizer experiment.
+ */
+class ExperimentDeleteForm extends ContentEntityDeleteForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    /** @var \Drupal\content_optimizer\Entity\Experiment $entity */
+    $entity = $this->getEntity();
+    return $this->t('Are you sure you want to delete the experiment for %label?', [
+      '%label' => $entity->getExperimentLabel(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->t('This will delete the experiment configuration. RL tracking data can be cleaned up separately in the RL reports.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('content_optimizer.experiments');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+    $this->messenger()->addStatus($this->t('Experiment deleted.'));
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/modules/content_optimizer/src/Form/ExperimentForm.php
+++ b/modules/content_optimizer/src/Form/ExperimentForm.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Drupal\content_optimizer\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\content_optimizer\Service\ExperimentRegistrationService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form for creating and editing Content Optimizer experiments.
+ */
+class ExperimentForm extends ContentEntityForm {
+
+  /**
+   * The experiment registration service.
+   *
+   * @var \Drupal\content_optimizer\Service\ExperimentRegistrationService
+   */
+  protected ExperimentRegistrationService $registrationService;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $instance = parent::create($container);
+    $instance->registrationService = $container->get('content_optimizer.experiment_registration');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    /** @var \Drupal\content_optimizer\Entity\Experiment $experiment */
+    $experiment = $this->entity;
+    $is_new = $experiment->isNew();
+
+    // Pre-populate from query parameters (linked from node form).
+    $request = $this->getRequest();
+
+    $form['target_entity_type'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Entity type'),
+      '#required' => TRUE,
+      '#default_value' => $experiment->get('target_entity_type')->value ?: ($request->query->get('entity_type') ?? 'node'),
+      '#description' => $this->t('Machine name of the entity type (e.g., node, menu_link_content).'),
+      '#disabled' => !$is_new,
+    ];
+
+    $form['target_entity_id'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Entity ID'),
+      '#default_value' => $experiment->get('target_entity_id')->value ?: $request->query->get('entity_id'),
+      '#description' => $this->t('The numeric ID of the entity to test. Leave empty for path-based experiments.'),
+      '#min' => 1,
+      '#disabled' => !$is_new,
+    ];
+
+    $form['target_field'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Field'),
+      '#required' => TRUE,
+      '#default_value' => $experiment->get('target_field')->value ?: ($request->query->get('field') ?? 'title'),
+      '#description' => $this->t('The field to test (e.g., title).'),
+      '#disabled' => !$is_new,
+    ];
+
+    $form['target_path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Path'),
+      '#default_value' => $experiment->get('target_path')->value,
+      '#description' => $this->t('For non-entity experiments, the page path (e.g., /blog).'),
+      '#states' => [
+        'visible' => [
+          ':input[name="target_entity_id"]' => ['value' => ''],
+        ],
+      ],
+    ];
+
+    $form['enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enabled'),
+      '#default_value' => $is_new ? TRUE : $experiment->isPublished(),
+    ];
+
+    // Variants section.
+    $form['variants_section'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Variants'),
+      '#description' => $this->t('The original field value is always tested as "v0". Add alternative texts below.'),
+      '#prefix' => '<div id="content-optimizer-variants-wrapper">',
+      '#suffix' => '</div>',
+    ];
+
+    $existing_variants = $experiment->getVariants();
+    $num_variants = $form_state->get('num_variants');
+    if ($num_variants === NULL) {
+      $num_variants = max(1, count($existing_variants));
+      $form_state->set('num_variants', $num_variants);
+    }
+
+    for ($i = 0; $i < $num_variants; $i++) {
+      $form['variants_section']['variant_' . $i] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Variant @num', ['@num' => $i + 1]),
+        '#default_value' => $existing_variants[$i] ?? '',
+        '#maxlength' => 512,
+      ];
+    }
+
+    $form['variants_section']['add_variant'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Add variant'),
+      '#submit' => ['::addVariantSubmit'],
+      '#ajax' => [
+        'callback' => '::variantsAjaxCallback',
+        'wrapper' => 'content-optimizer-variants-wrapper',
+      ],
+      '#limit_validation_errors' => [],
+      '#button_type' => 'small',
+    ];
+
+    if ($num_variants > 1) {
+      $form['variants_section']['remove_variant'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Remove last variant'),
+        '#submit' => ['::removeVariantSubmit'],
+        '#ajax' => [
+          'callback' => '::variantsAjaxCallback',
+          'wrapper' => 'content-optimizer-variants-wrapper',
+        ],
+        '#limit_validation_errors' => [],
+        '#button_type' => 'small',
+      ];
+    }
+
+    // Remove the auto-generated base field widgets we handle manually.
+    unset($form['variants_data']);
+
+    return $form;
+  }
+
+  /**
+   * AJAX callback for variants section.
+   */
+  public function variantsAjaxCallback(array &$form, FormStateInterface $form_state) {
+    return $form['variants_section'];
+  }
+
+  /**
+   * Submit handler for adding a variant.
+   */
+  public function addVariantSubmit(array &$form, FormStateInterface $form_state) {
+    $num = $form_state->get('num_variants') ?? 1;
+    $form_state->set('num_variants', $num + 1);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Submit handler for removing a variant.
+   */
+  public function removeVariantSubmit(array &$form, FormStateInterface $form_state) {
+    $num = $form_state->get('num_variants') ?? 1;
+    if ($num > 1) {
+      $form_state->set('num_variants', $num - 1);
+    }
+    $form_state->setRebuild();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    $entity_id = $form_state->getValue('target_entity_id');
+    $path = $form_state->getValue('target_path');
+
+    if (empty($entity_id) && empty($path)) {
+      $form_state->setErrorByName('target_entity_id', $this->t('Provide either an entity ID or a path.'));
+    }
+
+    // Check at least one variant has text.
+    $has_variant = FALSE;
+    $num_variants = $form_state->get('num_variants') ?? 1;
+    for ($i = 0; $i < $num_variants; $i++) {
+      if (!empty(trim($form_state->getValue('variant_' . $i) ?? ''))) {
+        $has_variant = TRUE;
+        break;
+      }
+    }
+    if (!$has_variant) {
+      $form_state->setErrorByName('variant_0', $this->t('Add at least one variant text.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\content_optimizer\Entity\Experiment $experiment */
+    $experiment = $this->entity;
+
+    // Collect variant texts.
+    $variants = [];
+    $num_variants = $form_state->get('num_variants') ?? 1;
+    for ($i = 0; $i < $num_variants; $i++) {
+      $text = trim($form_state->getValue('variant_' . $i) ?? '');
+      if (!empty($text)) {
+        $variants[] = $text;
+      }
+    }
+    $experiment->setVariants($variants);
+
+    // Set published status.
+    if ($form_state->getValue('enabled')) {
+      $experiment->setPublished();
+    }
+    else {
+      $experiment->setUnpublished();
+    }
+
+    $status = $experiment->save();
+
+    // Register with RL.
+    $this->registrationService->register(
+      $experiment->getRlExperimentId(),
+      $experiment->getExperimentLabel()
+    );
+
+    if ($status === SAVED_NEW) {
+      $this->messenger()->addStatus($this->t('Experiment created. Variants will be tested on the next page view.'));
+    }
+    else {
+      $this->messenger()->addStatus($this->t('Experiment updated.'));
+    }
+
+    $form_state->setRedirectUrl(Url::fromRoute('content_optimizer.experiments'));
+  }
+
+}

--- a/modules/content_optimizer/src/Form/SettingsForm.php
+++ b/modules/content_optimizer/src/Form/SettingsForm.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Drupal\content_optimizer\Form;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Configuration form for Content Optimizer.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $instance = parent::create($container);
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'content_optimizer_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['content_optimizer.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('content_optimizer.settings');
+
+    $form['reward'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Reward Strategy'),
+      '#open' => TRUE,
+    ];
+
+    $form['reward']['reward_strategy'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Reward signal'),
+      '#options' => [
+        'time_on_page' => $this->t('Time on page'),
+        'scroll_depth' => $this->t('Scroll depth (50%)'),
+        'next_click' => $this->t('Any click on the page'),
+      ],
+      '#default_value' => $config->get('reward_strategy') ?? 'time_on_page',
+      '#description' => $this->t('How to determine if a variant performed well.'),
+    ];
+
+    $form['reward']['reward_threshold'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Time threshold (seconds)'),
+      '#default_value' => $config->get('reward_threshold') ?? 10,
+      '#min' => 1,
+      '#max' => 300,
+      '#description' => $this->t('For time-on-page strategy: seconds before counting as a reward.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="reward_strategy"]' => ['value' => 'time_on_page'],
+        ],
+      ],
+    ];
+
+    $form['entity_types_section'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Entity Type Support'),
+      '#open' => TRUE,
+    ];
+
+    // Build checkboxes for content entity types.
+    $entity_type_options = [];
+    foreach ($this->entityTypeManager->getDefinitions() as $id => $definition) {
+      if ($definition->getGroup() === 'content' && $definition->hasLinkTemplate('canonical')) {
+        $entity_type_options[$id] = $definition->getLabel();
+      }
+    }
+
+    $form['entity_types_section']['entity_types'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Show variant editor on forms for'),
+      '#options' => $entity_type_options,
+      '#default_value' => $config->get('entity_types') ?? ['node'],
+      '#description' => $this->t('Entity types that show the "Title variants" vertical tab on edit forms.'),
+    ];
+
+    $form['performance'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Performance'),
+      '#open' => TRUE,
+    ];
+
+    $form['performance']['cache_ttl'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Cache TTL (seconds)'),
+      '#default_value' => $config->get('cache_ttl') ?? 60,
+      '#min' => 0,
+      '#max' => 86400,
+      '#description' => $this->t('Page cache lifetime for pages with active experiments. Lower values mean faster learning but more server load.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    $entity_types = array_values(array_filter($form_state->getValue('entity_types')));
+
+    $this->config('content_optimizer.settings')
+      ->set('reward_strategy', $form_state->getValue('reward_strategy'))
+      ->set('reward_threshold', (int) $form_state->getValue('reward_threshold'))
+      ->set('entity_types', $entity_types)
+      ->set('cache_ttl', (int) $form_state->getValue('cache_ttl'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/content_optimizer/src/Service/ExperimentRegistrationService.php
+++ b/modules/content_optimizer/src/Service/ExperimentRegistrationService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\content_optimizer\Service;
+
+use Drupal\rl\Registry\ExperimentRegistryInterface;
+
+/**
+ * Registers content optimizer experiments with the RL experiment registry.
+ */
+class ExperimentRegistrationService {
+
+  /**
+   * The RL experiment registry.
+   *
+   * @var \Drupal\rl\Registry\ExperimentRegistryInterface
+   */
+  protected ExperimentRegistryInterface $experimentRegistry;
+
+  /**
+   * Constructs an ExperimentRegistrationService.
+   *
+   * @param \Drupal\rl\Registry\ExperimentRegistryInterface $experiment_registry
+   *   The RL experiment registry.
+   */
+  public function __construct(ExperimentRegistryInterface $experiment_registry) {
+    $this->experimentRegistry = $experiment_registry;
+  }
+
+  /**
+   * Register an experiment with the RL system.
+   *
+   * @param string $experiment_id
+   *   The deterministic experiment ID.
+   * @param string|null $experiment_name
+   *   Human-readable name.
+   */
+  public function register(string $experiment_id, ?string $experiment_name = NULL): void {
+    $this->experimentRegistry->register($experiment_id, 'content_optimizer', $experiment_name);
+  }
+
+}

--- a/modules/content_optimizer/src/Service/VariantSelector.php
+++ b/modules/content_optimizer/src/Service/VariantSelector.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\content_optimizer\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\rl\Service\CacheManager;
+use Drupal\rl\Service\ExperimentManagerInterface;
+
+/**
+ * Selects the best-performing variant using Thompson Sampling.
+ */
+class VariantSelector {
+
+  /**
+   * The RL experiment manager.
+   *
+   * @var \Drupal\rl\Service\ExperimentManagerInterface
+   */
+  protected ExperimentManagerInterface $experimentManager;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The RL cache manager.
+   *
+   * @var \Drupal\rl\Service\CacheManager
+   */
+  protected CacheManager $cacheManager;
+
+  /**
+   * Constructs a VariantSelector.
+   *
+   * @param \Drupal\rl\Service\ExperimentManagerInterface $experiment_manager
+   *   The RL experiment manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\rl\Service\CacheManager $cache_manager
+   *   The RL cache manager.
+   */
+  public function __construct(ExperimentManagerInterface $experiment_manager, EntityTypeManagerInterface $entity_type_manager, CacheManager $cache_manager) {
+    $this->experimentManager = $experiment_manager;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->cacheManager = $cache_manager;
+  }
+
+  /**
+   * Select the best variant for an entity field.
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   * @param int $entity_id
+   *   The entity ID.
+   * @param string $field
+   *   The field name (default: 'title').
+   *
+   * @return array|null
+   *   Array with keys 'experiment_id', 'arm_id', 'text' (NULL = use original),
+   *   'experiment_entity_id', or NULL if no active experiment.
+   */
+  public function selectVariant(string $entity_type, int $entity_id, string $field = 'title'): ?array {
+    $experiments = $this->entityTypeManager
+      ->getStorage('content_optimizer_experiment')
+      ->loadByProperties([
+        'target_entity_type' => $entity_type,
+        'target_entity_id' => $entity_id,
+        'target_field' => $field,
+        'enabled' => TRUE,
+      ]);
+
+    if (empty($experiments)) {
+      return NULL;
+    }
+
+    /** @var \Drupal\content_optimizer\Entity\Experiment $experiment */
+    $experiment = reset($experiments);
+    $variants = $experiment->getVariants();
+
+    if (empty($variants)) {
+      return NULL;
+    }
+
+    $experiment_id = $experiment->getRlExperimentId();
+    $arm_ids = $experiment->getArmIds();
+
+    $scores = $this->experimentManager->getThompsonScores($experiment_id, NULL, $arm_ids);
+
+    // Pick the highest-scoring arm.
+    arsort($scores);
+    $best_arm = key($scores);
+
+    // Override page cache TTL so variants rotate.
+    $config = \Drupal::config('content_optimizer.settings');
+    $cache_ttl = $config->get('cache_ttl') ?? 60;
+    $this->cacheManager->overridePageCacheIfShorter($cache_ttl);
+
+    return [
+      'experiment_id' => $experiment_id,
+      'arm_id' => $best_arm,
+      'text' => $experiment->getArmText($best_arm),
+      'experiment_entity_id' => $experiment->id(),
+    ];
+  }
+
+}


### PR DESCRIPTION
## Summary

New RL ecosystem submodule (`modules/content_optimizer/`) that enables A/B testing of page titles, menu link labels, and other entity text fields using Thompson Sampling.

Implements #33

## Architecture

- **Content entity** (`content_optimizer_experiment`) stores target entity reference, field name, and JSON-encoded variant texts
- **VariantSelector service** calls `rl.experiment_manager->getThompsonScores()` to pick the winning variant at render time
- **Experiment decorator** shows human-readable variant text in RL reports instead of raw arm IDs (v0, v1, ...)
- Arms: `v0` = original entity field value (read live), `v1`+ = stored variants

## Features

### In-context UI (vertical tab on entity forms)
- Collapsed "Title variants" details element in the advanced tabs group
- AJAX-powered add/remove variant buttons
- Live experiment status (impressions, current leader) with link to RL report
- Configurable per entity type via settings

### Admin UI
- **List page** (`/admin/config/content/content-optimizer`): shows target, field, variant count, impressions, leader, conversion score, status, operations (edit/delete/report)
- **Add/Edit form**: standalone form with entity type/ID fields, variant management, enable toggle
- **Delete confirmation** with cleanup guidance
- **Settings** (`/admin/config/content/content-optimizer/settings`): reward strategy, entity type support, cache TTL
- Proper menu link, task tabs (Experiments | Settings), action link (Add experiment)

### Title A/B testing
- `hook_preprocess_page_title()` overrides the visible `<h1>`
- `hook_preprocess_html()` overrides the `<title>` tag
- Static caching per request to avoid duplicate scoring
- Cache TTL override via `rl.cache_manager`

### Menu link A/B testing
- `hook_preprocess_menu()` with recursive item processing
- IntersectionObserver for impression tracking
- Click listener for reward tracking

### Client-side tracking
- **title-tracking.js**: records turn on page load, reward based on configurable strategy:
  - Time on page (default: 10s threshold)
  - Scroll depth (50%)
  - Any click on page
- **menu-tracking.js**: IntersectionObserver for turns, click for rewards
- Both use `navigator.sendBeacon()` to `rl.php` for non-blocking tracking
- Session storage prevents duplicate rewards

### RL integration
- `ExperimentRegistrationService` wraps `rl.experiment_registry`
- `ContentOptimizerDecorator` tagged as `rl_experiment_decorator` for report labels
- Automatic cleanup via `hook_entity_delete()` when target entity is deleted

## Files (24 total)

```
modules/content_optimizer/
  content_optimizer.info.yml          # Module metadata, RL package
  content_optimizer.module            # Hooks: form_alter, preprocess, entity_delete
  content_optimizer.install           # Uninstall cleanup
  content_optimizer.services.yml      # 3 services + decorator tag
  content_optimizer.routing.yml       # 5 routes
  content_optimizer.permissions.yml   # 1 permission
  content_optimizer.libraries.yml     # 3 libraries (title-tracking, menu-tracking, admin CSS)
  content_optimizer.links.*.yml       # Menu, task tabs, action links
  config/install/                     # Default settings
  config/schema/                      # Config schema
  src/Entity/Experiment.php           # Content entity with variant helpers
  src/ExperimentAccessControlHandler.php
  src/ExperimentListBuilder.php       # List with live RL stats
  src/Form/ExperimentForm.php         # AJAX variant management
  src/Form/ExperimentDeleteForm.php
  src/Form/SettingsForm.php           # Reward strategy, entity types, cache TTL
  src/Service/VariantSelector.php     # Thompson scoring + selection
  src/Service/ExperimentRegistrationService.php
  src/Decorator/ContentOptimizerDecorator.php
  js/title-tracking.js
  js/menu-tracking.js
  css/content-optimizer.admin.css
```

## Test plan

- [ ] Install module, verify entity table created
- [ ] Create a node, add title variants via vertical tab, save
- [ ] View the node -- verify title changes based on Thompson Sampling
- [ ] Check browser network tab for sendBeacon calls to rl.php
- [ ] Wait past reward threshold, verify reward recorded
- [ ] Check RL reports at /admin/reports/rl -- experiment appears with decorated arm labels
- [ ] Admin list at /admin/config/content/content-optimizer shows experiment with stats
- [ ] Edit experiment via admin form, add/remove variants
- [ ] Delete experiment, verify cleanup
- [ ] Settings form: change reward strategy, entity types, cache TTL
- [ ] Delete the node, verify experiment auto-deleted