### PR TITLE
fix: install lookup_hash column for existing sites via hook_update_10001

### DIFF
--- a/modules/rl_menu_link/rl_menu_link.install
+++ b/modules/rl_menu_link/rl_menu_link.install
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall hooks for rl_menu_link.
+ */
+
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Utility\UpdateException;
+use Drupal\rl_menu_link\Entity\MenuLinkExperiment;
+
+/**
+ * Add lookup_hash column, backfill existing rows, and add hash-based indexes.
+ *
+ * The hash-indexed lookup refactor introduced a computed `lookup_hash` base
+ * field, a UNIQUE index on that column, and a secondary
+ * (menu_link_plugin_id, langcode) index. Fresh installs pick this up from
+ * the entity class's storage schema, but existing sites need this update
+ * to avoid a QueryException from the runtime selector, which now filters
+ * on `lookup_hash`.
+ */
+function rl_menu_link_update_10001(): string {
+  $database = \Drupal::database();
+  $schema = $database->schema();
+  $table = 'rl_menu_link_experiment';
+  $entity_type_id = 'rl_menu_link_experiment';
+
+  // 1. Add the column if missing. NOT NULL with empty default so existing
+  //    rows get a placeholder which we immediately backfill below.
+  if (!$schema->fieldExists($table, 'lookup_hash')) {
+    $schema->addField($table, 'lookup_hash', [
+      'type' => 'varchar',
+      'length' => 64,
+      'not null' => TRUE,
+      'default' => '',
+      'description' => 'Computed hash of (menu_link_plugin_id | langcode) for indexed runtime lookup.',
+    ]);
+  }
+
+  // 2. Backfill hashes from each row's (menu_link_plugin_id, langcode)
+  //    using the same algorithm preSave() uses so new code's lookups match.
+  $rows = $database->select($table, 't')
+    ->fields('t', ['id', 'menu_link_plugin_id', 'langcode'])
+    ->execute()
+    ->fetchAll();
+  foreach ($rows as $row) {
+    $plugin_id = (string) ($row->menu_link_plugin_id ?? '');
+    $langcode = (string) ($row->langcode ?: LanguageInterface::LANGCODE_NOT_SPECIFIED);
+    $hash = MenuLinkExperiment::computeLookupHash($plugin_id, $langcode);
+    $database->update($table)
+      ->fields(['lookup_hash' => $hash])
+      ->condition('id', $row->id)
+      ->execute();
+  }
+
+  // 3. Refuse to add the UNIQUE index if any pre-existing duplicate
+  //    (plugin_id, langcode) rows exist.
+  $duplicates = $database->query(
+    "SELECT lookup_hash, COUNT(*) AS n FROM {" . $table . "} GROUP BY lookup_hash HAVING n > 1"
+  )->fetchAll();
+  if ($duplicates) {
+    $hashes = array_map(static fn ($row) => $row->lookup_hash, $duplicates);
+    throw new UpdateException('rl_menu_link_experiment contains duplicate (menu_link_plugin_id, langcode) rows. Delete duplicates before re-running this update. Offending lookup_hash values: ' . implode(', ', $hashes));
+  }
+
+  // 4. Apply the UNIQUE key and secondary composite index declared by
+  //    MenuLinkExperimentStorageSchema. indexExists() is true for unique
+  //    keys on MySQL, so both branches are idempotent.
+  if (!$schema->indexExists($table, 'rl_menu_link_lookup_hash')) {
+    $schema->addUniqueKey($table, 'rl_menu_link_lookup_hash', ['lookup_hash']);
+  }
+  if (!$schema->indexExists($table, 'rl_menu_link_plugin_langcode')) {
+    $schema->addIndex($table, 'rl_menu_link_plugin_langcode', [['menu_link_plugin_id', 191], 'langcode'], [
+      'fields' => [
+        'menu_link_plugin_id' => [
+          'type' => 'varchar',
+          'length' => 255,
+          'not null' => TRUE,
+        ],
+        'langcode' => [
+          'type' => 'varchar',
+          'length' => 12,
+          'not null' => TRUE,
+        ],
+      ],
+    ]);
+  }
+
+  // 5. Register the base field with Drupal's entity system. We bypass
+  //    EntityDefinitionUpdateManager::installFieldStorageDefinition() here
+  //    because it would try to re-apply the full storage schema (including
+  //    the UNIQUE key we already added) and blow up on "key already exists".
+  //    Writing directly to the last-installed schema repository records
+  //    the field so getChangeSummary() stops reporting drift, without
+  //    touching the SQL layer.
+  $lookup_hash_definition = BaseFieldDefinition::create('string')
+    ->setName('lookup_hash')
+    ->setTargetEntityTypeId($entity_type_id)
+    ->setLabel(t('Lookup hash'))
+    ->setDescription(t('Computed sha256(menu_link_plugin_id|langcode). Uniquely identifies an experiment for indexed runtime lookup.'))
+    ->setRequired(TRUE)
+    ->setSetting('max_length', 64)
+    ->setReadOnly(TRUE);
+  \Drupal::service('entity.last_installed_schema.repository')
+    ->setLastInstalledFieldStorageDefinition($lookup_hash_definition);
+
+  return (string) t('Added lookup_hash column, backfilled @count existing rows, and applied hash-based indexes on rl_menu_link_experiment.', ['@count' => count($rows)]);
+}

--- a/modules/rl_page_title/rl_page_title.install
+++ b/modules/rl_page_title/rl_page_title.install
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall hooks for rl_page_title.
+ */
+
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Utility\UpdateException;
+use Drupal\rl_page_title\Entity\PageTitleExperiment;
+
+/**
+ * Add lookup_hash column, backfill existing rows, and add hash-based indexes.
+ *
+ * The hash-indexed lookup refactor introduced a computed `lookup_hash` base
+ * field, a UNIQUE index on that column, and a secondary (path, langcode)
+ * index. Fresh installs pick this up from the entity class's storage schema,
+ * but existing sites need this update to avoid a QueryException from the
+ * runtime selector, which now filters on `lookup_hash`.
+ */
+function rl_page_title_update_10001(): string {
+  $database = \Drupal::database();
+  $schema = $database->schema();
+  $table = 'rl_page_title_experiment';
+  $entity_type_id = 'rl_page_title_experiment';
+
+  // 1. Add the column if missing. NOT NULL with empty default so existing
+  //    rows get a placeholder which we immediately backfill below.
+  if (!$schema->fieldExists($table, 'lookup_hash')) {
+    $schema->addField($table, 'lookup_hash', [
+      'type' => 'varchar',
+      'length' => 64,
+      'not null' => TRUE,
+      'default' => '',
+      'description' => 'Computed hash of (normalized path | langcode) for indexed runtime lookup.',
+    ]);
+  }
+
+  // 2. Backfill hashes from each row's (path, langcode) using the same
+  //    algorithm preSave() uses so new code's lookups match the backfilled
+  //    values exactly.
+  $rows = $database->select($table, 't')
+    ->fields('t', ['id', 'path', 'langcode'])
+    ->execute()
+    ->fetchAll();
+  foreach ($rows as $row) {
+    $path = (string) ($row->path ?? '');
+    $langcode = (string) ($row->langcode ?: LanguageInterface::LANGCODE_NOT_SPECIFIED);
+    $hash = PageTitleExperiment::computeLookupHash($path, $langcode);
+    $database->update($table)
+      ->fields(['lookup_hash' => $hash])
+      ->condition('id', $row->id)
+      ->execute();
+  }
+
+  // 3. Refuse to add the UNIQUE index if any pre-existing duplicate
+  //    (path, langcode) rows exist. Prior releases did form-level duplicate
+  //    detection but pre-normalization rows may still collide.
+  $duplicates = $database->query(
+    "SELECT lookup_hash, COUNT(*) AS n FROM {" . $table . "} GROUP BY lookup_hash HAVING n > 1"
+  )->fetchAll();
+  if ($duplicates) {
+    $hashes = array_map(static fn ($row) => $row->lookup_hash, $duplicates);
+    throw new UpdateException('rl_page_title_experiment contains duplicate (path, langcode) rows. Delete duplicates before re-running this update. Offending lookup_hash values: ' . implode(', ', $hashes));
+  }
+
+  // 4. Apply the UNIQUE key and secondary composite index declared by
+  //    PageTitleExperimentStorageSchema. indexExists() is true for unique
+  //    keys on MySQL, so both branches are idempotent.
+  if (!$schema->indexExists($table, 'rl_page_title_lookup_hash')) {
+    $schema->addUniqueKey($table, 'rl_page_title_lookup_hash', ['lookup_hash']);
+  }
+  if (!$schema->indexExists($table, 'rl_page_title_path_langcode')) {
+    $schema->addIndex($table, 'rl_page_title_path_langcode', [['path', 191], 'langcode'], [
+      'fields' => [
+        'path' => [
+          'type' => 'varchar',
+          'length' => 2048,
+          'not null' => FALSE,
+        ],
+        'langcode' => [
+          'type' => 'varchar',
+          'length' => 12,
+          'not null' => TRUE,
+        ],
+      ],
+    ]);
+  }
+
+  // 5. Register the base field with Drupal's entity system. We bypass
+  //    EntityDefinitionUpdateManager::installFieldStorageDefinition() here
+  //    because it would try to re-apply the full storage schema (including
+  //    the UNIQUE key we already added) and blow up on "key already exists".
+  //    Writing directly to the last-installed schema repository records
+  //    the field so getChangeSummary() stops reporting drift, without
+  //    touching the SQL layer.
+  $lookup_hash_definition = BaseFieldDefinition::create('string')
+    ->setName('lookup_hash')
+    ->setTargetEntityTypeId($entity_type_id)
+    ->setLabel(t('Lookup hash'))
+    ->setDescription(t('Computed sha256(path|langcode). Uniquely identifies an experiment for indexed runtime lookup.'))
+    ->setRequired(TRUE)
+    ->setSetting('max_length', 64)
+    ->setReadOnly(TRUE);
+  \Drupal::service('entity.last_installed_schema.repository')
+    ->setLastInstalledFieldStorageDefinition($lookup_hash_definition);
+
+  return (string) t('Added lookup_hash column, backfilled @count existing rows, and applied hash-based indexes on rl_page_title_experiment.', ['@count' => count($rows)]);
+}


### PR DESCRIPTION
## Summary

- Adds `rl_page_title_update_10001()` and `rl_menu_link_update_10001()` so existing sites installed before the hash-indexed lookup refactor (commit e215a95) get the new `lookup_hash` column, backfilled hashes, UNIQUE key, and secondary composite index.
- Without this, `VariantSelectorBase::loadExperimentByLookupHashes()` throws `QueryException: 'lookup_hash' not found` on every page render, 500ing anything that hits `hook_page_attachments`.
- The original refactor deliberately skipped a hook_update calling out "modules have not been released." That is not a valid reason to skip schema updates in a contrib module — any preview checkout, -dev follower, or tagged site upgrading across this refactor will crash.

## How each update works

1. `$schema->addField()` adds `lookup_hash varchar(64) NOT NULL DEFAULT ''` so the NOT NULL add does not fail on tables with rows.
2. Direct DB update backfills hashes using `{PageTitle,MenuLink}Experiment::computeLookupHash()` so values match exactly what `preSave()` writes at runtime.
3. A pre-check throws `UpdateException` with the offending hash set if any rows collide (prevents the UNIQUE key add from exploding mid-migration).
4. `addUniqueKey()` + `addIndex()` apply the schema declared by the storage schema classes.
5. Field is registered with the entity system via `entity.last_installed_schema.repository::setLastInstalledFieldStorageDefinition()`, deliberately bypassing `EntityDefinitionUpdateManager::installFieldStorageDefinition()` because that re-applies the full storage schema and fails on "key already exists".

## Test plan

- [x] `drush updb -y` on a site with the old schema runs both updates, backfills existing rows, applies indexes.
- [x] `SHOW INDEX FROM rl_page_title_experiment` confirms `rl_page_title_lookup_hash` (UNIQUE) + `rl_page_title_path_langcode` (composite, 191-char prefix).
- [x] `SHOW INDEX FROM rl_menu_link_experiment` confirms `rl_menu_link_lookup_hash` (UNIQUE) + `rl_menu_link_plugin_langcode` (composite, 191-char prefix).
- [x] Previously-500ing `/home` returns 200 after the update.
- [x] No new `lookup_hash` QueryException rows in watchdog after the fix.
- [x] `drush updb` re-run shows "No pending updates" (idempotent).
- [ ] Re-run on a multilingual site with per-language experiment rows to confirm hash collisions do not trip the UNIQUE check.
- [ ] Verify on a site with legacy unnormalized paths (trailing slash, missing leading slash) that the backfill does not collide.