### PR TITLE
feat(reports): add Created column to experiments overview

### DIFF
--- a/src/Controller/ReportsController.php
+++ b/src/Controller/ReportsController.php
@@ -147,6 +147,7 @@ class ReportsController extends ControllerBase {
       $this->t('Impressions'),
       $this->t('Conversions'),
       $this->t('Variants'),
+      $this->t('Created'),
       $this->t('Last Activity'),
     ];
 
@@ -184,6 +185,10 @@ class ReportsController extends ControllerBase {
             ? $this->dateFormatter->format($last_activity_timestamp, 'short')
             : $this->t('Never');
 
+      $created = $experiment->registered_at > 0
+            ? $this->dateFormatter->format($experiment->registered_at, 'short')
+            : $this->t('Never');
+
       // Use experiment name from registry or fallback to experiment ID.
       $experiment_name = $experiment->experiment_name ?: $experiment->experiment_id;
 
@@ -194,6 +199,7 @@ class ReportsController extends ControllerBase {
         $experiment->total_turns ?: 0,
         $total_rewards,
         $arms_count,
+        $created,
         $last_activity,
       ];
     }


### PR DESCRIPTION
## Summary

- Adds a **Created** column to `/admin/reports/rl` rendering each experiment's `registered_at` timestamp.
- Sits between **Variants** and **Last Activity** so the two timestamps line up for quick comparison.
- Reuses the row already loaded by `ExperimentDataStorage::getExperimentsWithStats()`; no extra queries.

Closes #46

## Test plan

- [ ] Visit `/admin/reports/rl` with multiple experiments; confirm new Created column shows formatted timestamps.
- [ ] Confirm a freshly-registered experiment with no traffic shows a Created date and "Never" Last Activity.
- [ ] Confirm an experiment whose `registered_at` is 0 (legacy data, if any) renders "Never".