### PR TITLE
feat(reports): add styled chart header with icon and subtitle

### DIFF
--- a/css/rl-charts.css
+++ b/css/rl-charts.css
@@ -3,6 +3,50 @@
  * Styles for RL experiment charts.
  */
 
+/* Chart header with icon */
+.rl-chart-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75em;
+  margin-bottom: 1.25em;
+}
+
+.rl-chart-header__icon {
+  flex-shrink: 0;
+  width: 2.5em;
+  height: 2.5em;
+  background: linear-gradient(135deg, var(--rl-color-1), var(--rl-color-5), var(--rl-color-8));
+  border-radius: 0.5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+
+.rl-chart-header__icon svg {
+  width: 1.4em;
+  height: 1.4em;
+}
+
+.rl-chart-header__text {
+  min-width: 0;
+}
+
+.rl-chart-header__title {
+  margin: 0;
+  font-size: 1.5em;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #111;
+}
+
+.rl-chart-header__subtitle {
+  margin: 0.15em 0 0;
+  font-size: 0.95em;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
 .rl-charts-container {
   margin-bottom: 2em;
 }

--- a/css/rl-charts.css
+++ b/css/rl-charts.css
@@ -15,7 +15,7 @@
   flex-shrink: 0;
   width: 2.5em;
   height: 2.5em;
-  background: linear-gradient(135deg, var(--rl-color-1, #0077B6), var(--rl-color-5, #26828E), var(--rl-color-8, #6CCE59));
+  background: linear-gradient(135deg, var(--rl-color-1), var(--rl-color-5), var(--rl-color-8));
   border-radius: 0.5em;
   display: flex;
   align-items: center;

--- a/css/rl-charts.css
+++ b/css/rl-charts.css
@@ -15,7 +15,7 @@
   flex-shrink: 0;
   width: 2.5em;
   height: 2.5em;
-  background: linear-gradient(135deg, var(--rl-color-1), var(--rl-color-5), var(--rl-color-8));
+  background: linear-gradient(135deg, var(--rl-color-1, #0077B6), var(--rl-color-5, #26828E), var(--rl-color-8, #6CCE59));
   border-radius: 0.5em;
   display: flex;
   align-items: center;

--- a/rl.libraries.yml
+++ b/rl.libraries.yml
@@ -28,6 +28,7 @@ plotly:
     - core/drupal
     - core/drupalSettings
     - core/once
+    - rl/experiment-highlight
 
 date-filter:
   version: 1.0
@@ -39,3 +40,4 @@ date-filter:
   dependencies:
     - core/drupal
     - core/once
+    - rl/experiment-highlight

--- a/rl.module
+++ b/rl.module
@@ -30,6 +30,7 @@ function rl_theme() {
     'rl_charts' => [
       'variables' => [
         'title' => NULL,
+        'subtitle' => NULL,
         'tip_hover' => NULL,
         'tip_taller' => NULL,
         'interaction_hint' => NULL,

--- a/src/Controller/ReportsController.php
+++ b/src/Controller/ReportsController.php
@@ -623,7 +623,8 @@ class ReportsController extends ControllerBase {
 
     $build['charts'] = [
       '#theme' => 'rl_charts',
-      '#title' => $this->t('Performance Over Time'),
+      '#title' => $this->t('Variant Performance'),
+      '#subtitle' => $this->t('Conversion score (%) by total impressions and content variant'),
       '#tip_hover' => $this->t('Hover for details. Higher = better.'),
       '#tip_taller' => $this->t('Hover for details. Taller/brighter = better conversion score.'),
       '#interaction_hint' => $this->t('Drag to rotate @bullet Scroll to zoom', ['@bullet' => '•']),

--- a/templates/rl-charts.html.twig
+++ b/templates/rl-charts.html.twig
@@ -5,13 +5,24 @@
  *
  * Available variables:
  * - title: The section title.
+ * - subtitle: Optional descriptive subtitle below the title.
  * - tip_hover: Tip text for hover.
  * - tip_taller: Tip text for 3D landscape.
  * - interaction_hint: Hint for 3D interaction.
  * - date_filter: Date filter dropdowns render array.
  */
 #}
-<h3>{{ title }}</h3>
+<div class="rl-chart-header">
+  <div class="rl-chart-header__icon" aria-hidden="true">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+  </div>
+  <div class="rl-chart-header__text">
+    <h3 class="rl-chart-header__title">{{ title }}</h3>
+    {% if subtitle %}
+      <p class="rl-chart-header__subtitle">{{ subtitle }}</p>
+    {% endif %}
+  </div>
+</div>
 
 <div class="rl-chart-tabs-wrapper">
   {% if date_filter %}


### PR DESCRIPTION
## Summary

- Replace plain `<h3>` with a flex header component: gradient icon, title, and optional subtitle
- Rename title from "Performance Over Time" to "Variant Performance" for clarity
- Add subtitle "Conversion score (%) by total impressions and content variant" to explain what the chart shows
- Register new `subtitle` theme variable in `rl_charts` theme hook

Closes #56

## Test plan

- [ ] Visit an experiment's report page and verify the new header renders with icon, title, and subtitle
- [ ] Confirm the gradient icon uses the RL colour variables (`--rl-color-1`, `--rl-color-5`, `--rl-color-8`)
- [ ] Check that the subtitle is optional: if not set, no `<p>` element should appear