### PR TITLE
fix: avoid using void return value of Truncate::execute()

### DIFF
--- a/src/Storage/SnapshotStorage.php
+++ b/src/Storage/SnapshotStorage.php
@@ -467,7 +467,9 @@ class SnapshotStorage implements SnapshotStorageInterface {
    * {@inheritdoc}
    */
   public function deleteAll(): int {
-    return (int) $this->database->truncate('rl_arm_snapshots')->execute();
+    $count = $this->getCount();
+    $this->database->truncate('rl_arm_snapshots')->execute();
+    return $count;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `Truncate::execute()` returns `void` in Drupal's database API, so casting its result to `int` triggered PHPStan error `method.void`
- Fix: call `getCount()` before truncating and return that value, satisfying both the PHPStan check and the `SnapshotStorageInterface::deleteAll(): int` contract

## Test plan
- [ ] PHPStan CI check passes with no errors