### PR TITLE
feat: add rank() API for full Thompson Sampling ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ losses update toward lower. Algorithm details:
 - **A/B test any content variation** without third-party SaaS
 - **Multivariate test** dozens or thousands of variants at once
 - **Continuous optimization**: tests never end, the model keeps learning
+- **Engagement-ranked lists**: sort FAQs, accordions, carousels, or any list by what visitors actually click
 - **Recommendations**: rank items by real engagement
 - **Feature flags**: route users to variants based on observed reward, not coin flip
 
@@ -271,8 +272,9 @@ See `rl_sorting`'s Views sort plugin for the canonical pattern and
 
 Some consumers have to decide in JS: full-page-cached builders that
 render all variants into the HTML and swap them on the client so they
-can keep Varnish/Fastly caching. For that case there is
-`Drupal.rl.decide()`, documented below.
+can keep Varnish/Fastly caching. For those cases there are
+`Drupal.rl.decide()` (single winner) and `Drupal.rl.rank()` (full
+sorted order), documented below.
 
 ## JavaScript API (`Drupal.rl`)
 
@@ -297,11 +299,26 @@ Drupal.rl.decide('hero_cta', armIds).then(function (armId) {
   showVariant(armId);
 });
 
+// Ask for a full ranking when you need to reorder a list, not just
+// pick one winner (accordions, FAQs, carousels, sorted feeds).
+var items = document.querySelectorAll('[data-rl-arm]');
+var itemIds = Array.prototype.map.call(items, function (el) {
+  return el.dataset.rlArm;
+});
+Drupal.rl.rank('faq_sort', itemIds).then(function (sorted) {
+  // sorted = ['q3', 'q0', 'q1', 'q2'] (full ranked order, best first)
+  var parent = items[0].parentNode;
+  sorted.forEach(function (armId) {
+    var el = parent.querySelector('[data-rl-arm="' + armId + '"]');
+    parent.appendChild(el);
+  });
+});
+
 // Optional: force an immediate flush.
 Drupal.rl.flush();
 ```
 
-Events accumulate for 500 ms and then flush in one POST. Decide,
+Events accumulate for 500 ms and then flush in one POST. Decide, rank,
 turn, and reward events share the same queue and the same request, so
 a page with a DXPR Builder variant block plus tracking on other
 elements ends up making a single round trip. Buffered tracking events
@@ -328,8 +345,20 @@ node ids, anything matching `^[a-zA-Z0-9_-]+$`) is whatever you emit
 into the attribute. The rl core is arm-agnostic.
 
 If the server returns no decision for an experiment (not registered,
-no data, network error), the returned promise resolves to `armIds[0]`
-so callers never need a `.catch()` for the common path.
+no data, network error), `decide()` resolves to `armIds[0]` and
+`rank()` resolves to the caller-provided `armIds` array unchanged, so
+callers never need a `.catch()` for the common path.
+
+### `rank()` vs `decide()`
+
+`decide()` returns `Promise<string>`: one winning arm. Use it when you
+need to show a single variant (A/B hero images, page titles).
+
+`rank()` returns `Promise<Array<string>>`: the full arm list sorted by
+Thompson Sampling score, best first. Use it when you need to reorder a
+list of items by engagement (FAQ accordions, toggle lists, carousels,
+sorted feeds). Both methods share the same batch queue, so calling them
+on the same page costs no extra requests.
 
 `Drupal.rl` is one transport among several. Modules that already ship
 their own tracking JS (like `rl_sorting`, which batches turns on its
@@ -352,7 +381,7 @@ consumers keep using them unchanged.
 | `turn` | form POST | Record one impression. |
 | `turns` | form POST | Record impressions for many arms in one experiment. |
 | `reward` | form POST | Record one conversion. |
-| `batch` | JSON POST | Record turns and rewards across many experiments in one request. Used by `Drupal.rl`. |
+| `batch` | JSON POST | Decides, turns, and rewards across many experiments in one request. Used by `Drupal.rl`. |
 
 Experiment IDs and arm IDs must match `^[a-zA-Z0-9_-]+$`. Experiments
 must already be registered via `ExperimentRegistryInterface::register()`;
@@ -383,7 +412,8 @@ Content-Type: application/json
 
 {
   "decides": [
-    {"id": "hero_cta", "arms": ["v0", "v1", "v2"]}
+    {"id": "hero_cta", "arms": ["v0", "v1", "v2"]},
+    {"id": "faq_sort", "arms": ["q0", "q1", "q2", "q3"], "rank": true}
   ],
   "turns": [
     {"id": "hero_cta", "arm": "v0"},
@@ -400,12 +430,22 @@ dropped silently so one bad event does not poison the rest of the
 batch. The response is
 
 ```json
-{"ok":true,"decisions":{"hero_cta":{"armId":"v1"}}}
+{
+  "ok": true,
+  "decisions": {
+    "hero_cta": {"armId": "v1"},
+    "faq_sort": {"armId": "q2", "ranking": ["q2", "q0", "q3", "q1"]}
+  }
+}
 ```
 
 `decisions` contains only entries that had a successful Thompson
-Sampling lookup. Missing keys mean "use the default variant". Turns
-and rewards are fire-and-forget writes with no per-event response.
+Sampling lookup. Missing keys mean "use the default variant". When
+`"rank": true` is set on a decide entry, the response includes a
+`ranking` array with all arms sorted by score (best first). `armId`
+always equals `ranking[0]`. Callers that only need a single winner can
+ignore `ranking`. Turns and rewards are fire-and-forget writes with no
+per-event response.
 
 ### Curl examples
 

--- a/docs/rl_project_desc.html
+++ b/docs/rl_project_desc.html
@@ -31,7 +31,7 @@
 <ul>
   <li><strong>Multivariate by default</strong>: 2 to thousands of variants, no manual configuration</li>
   <li><strong>Real-time RLHF loop</strong>: visitor clicks update the model on every page</li>
-  <li><strong>Fast HTTP REST API</strong>: optimized JSON endpoint for tracking and decisions</li>
+  <li><strong>Fast HTTP REST API</strong>: optimized JSON endpoint for tracking, decisions, and full rankings</li>
   <li><strong>Admin reports</strong>: per-experiment performance, traffic, and confidence</li>
   <li><strong>Service-based architecture</strong>: extensible decorators, custom variant selectors</li>
   <li><strong>Data sovereignty</strong>: no cloud, no third-party SaaS, all data stays in your Drupal database</li>
@@ -44,6 +44,7 @@
   <li>You want to <strong>A/B or multivariate test</strong> any part of your site without third-party SaaS</li>
   <li>You want <strong>continuous optimization</strong> rather than fixed-horizon experiments</li>
   <li>You want to <strong>add or remove variants on the fly</strong> without restarting tests</li>
+  <li>You want to <strong>sort lists by engagement</strong> (FAQs, accordions, carousels) without burning page cache</li>
   <li>You want a <strong>core API</strong> you can call from any module, View, or block</li>
 </ul>
 
@@ -147,14 +148,21 @@ $best_arm = $ts_calculator-&gt;selectBestArm($scores);
 
 <p>Attach the <code>rl/api</code> library to get <code>Drupal.rl</code> on the page:</p>
 
-<pre><code>Drupal.rl.turn('hero_cta', 'v0');
-Drupal.rl.reward('hero_cta', 'v0');
-
+<pre><code>// Pick one winner (A/B variant selection).
 Drupal.rl.decide('hero_cta', ['v0', 'v1', 'v2']).then(function (armId) {
   showVariant(armId);
-});</code></pre>
+});
 
-<p>All three methods feed a shared 500 ms batch window, so every A/B test on the page rides one POST to <code>rl.php</code>. See the README for the HTTP wire format and server-side patterns.</p>
+// Get a full ranking (list sorting by engagement).
+Drupal.rl.rank('faq_sort', ['q0', 'q1', 'q2']).then(function (sorted) {
+  sorted.forEach(function (armId) { parent.appendChild(items[armId]); });
+});
+
+// Track impressions and conversions.
+Drupal.rl.turn('hero_cta', 'v0');
+Drupal.rl.reward('hero_cta', 'v0');</code></pre>
+
+<p>All methods feed a shared 500 ms batch window, so every A/B test on the page rides one POST to <code>rl.php</code>. See the README for the HTTP wire format and server-side patterns.</p>
 
 <h3>FAQ</h3>
 

--- a/js/rl.js
+++ b/js/rl.js
@@ -2,8 +2,9 @@
  * @file
  * Thin RL transport proxy with request batching.
  *
- * Exposes Drupal.rl.decide(), Drupal.rl.turn(), Drupal.rl.reward(), and
- * Drupal.rl.flush(). Batches calls into a single POST to rl.php so that
+ * Exposes Drupal.rl.decide(), Drupal.rl.rank(), Drupal.rl.turn(),
+ * Drupal.rl.reward(), and Drupal.rl.flush(). Batches calls into a
+ * single POST to rl.php so that
  * multiple RL-powered features on the same page share one request
  * instead of each making its own.
  *
@@ -45,6 +46,8 @@
     return {
       // experimentId -> { arms: [...], resolvers: [fn] }
       decides: Object.create(null),
+      // experimentId -> { arms: [...], resolvers: [fn] }
+      ranks: Object.create(null),
       turns: [],
       rewards: [],
     };
@@ -60,6 +63,11 @@
   function hasPending() {
     for (var id in queue.decides) {
       if (Object.prototype.hasOwnProperty.call(queue.decides, id)) {
+        return true;
+      }
+    }
+    for (var id in queue.ranks) {
+      if (Object.prototype.hasOwnProperty.call(queue.ranks, id)) {
         return true;
       }
     }
@@ -88,9 +96,18 @@
 
   function buildPayload(snapshot) {
     var decides = [];
+    var rankIds = Object.create(null);
+    for (var id in snapshot.ranks) {
+      if (Object.prototype.hasOwnProperty.call(snapshot.ranks, id)) {
+        decides.push({ id: id, arms: snapshot.ranks[id].arms, rank: true });
+        rankIds[id] = true;
+      }
+    }
     for (var id in snapshot.decides) {
       if (Object.prototype.hasOwnProperty.call(snapshot.decides, id)) {
-        decides.push({ id: id, arms: snapshot.decides[id].arms });
+        if (!rankIds[id]) {
+          decides.push({ id: id, arms: snapshot.decides[id].arms });
+        }
       }
     }
     return {
@@ -136,6 +153,37 @@
     }
   }
 
+  function resolveRanks(snapshot, decisions) {
+    for (var id in snapshot.ranks) {
+      if (!Object.prototype.hasOwnProperty.call(snapshot.ranks, id)) {
+        continue;
+      }
+      var entry = snapshot.ranks[id];
+      var ranking = null;
+      if (decisions && decisions[id] && Array.isArray(decisions[id].ranking)) {
+        ranking = decisions[id].ranking;
+      }
+      if (!ranking) {
+        ranking = entry.arms;
+      }
+      entry.resolvers.forEach(function (resolve) {
+        resolve(ranking);
+      });
+    }
+  }
+
+  function fallbackRanks(snapshot) {
+    for (var id in snapshot.ranks) {
+      if (!Object.prototype.hasOwnProperty.call(snapshot.ranks, id)) {
+        continue;
+      }
+      var entry = snapshot.ranks[id];
+      entry.resolvers.forEach(function (resolve) {
+        resolve(entry.arms);
+      });
+    }
+  }
+
   function flush() {
     if (!hasPending()) {
       return;
@@ -144,6 +192,7 @@
     var snapshot = takeQueue();
     if (!url) {
       fallbackDecides(snapshot);
+      fallbackRanks(snapshot);
       return;
     }
     var body = JSON.stringify(buildPayload(snapshot));
@@ -158,7 +207,7 @@
       // rl.php returns 422 when every entry in a non-empty batch was
       // rejected (unknown experiment, invalid ids, manager
       // unavailable). Read the JSON body anyway so the errors array
-      // reaches the console — without this, a site-wide mistake like
+      // reaches the console; without this, a site-wide mistake like
       // "registry cache missed the new hook so no experiment rows
       // exist" looks identical to a healthy empty batch and the
       // operator has nothing to grep for in devtools. Other non-2xx
@@ -166,16 +215,20 @@
       // useful body, so fall back.
       if (!response.ok && response.status !== 422) {
         fallbackDecides(snapshot);
+        fallbackRanks(snapshot);
         return null;
       }
       return response.json();
     }).then(function (json) {
       if (json) {
         reportErrors(json.errors);
-        resolveDecides(snapshot, json.decisions || {});
+        var decisions = json.decisions || {};
+        resolveDecides(snapshot, decisions);
+        resolveRanks(snapshot, decisions);
       }
     }).catch(function () {
       fallbackDecides(snapshot);
+      fallbackRanks(snapshot);
     });
   }
 
@@ -211,9 +264,11 @@
     var snapshot = takeQueue();
 
     // sendBeacon is fire-and-forget: we cannot read the response, so
-    // pending decides cannot be fulfilled from this path. Resolve them
-    // with the default fallback. The page is navigating away anyway.
+    // pending decides and ranks cannot be fulfilled from this path.
+    // Resolve them with their default fallbacks. The page is navigating
+    // away anyway.
     fallbackDecides(snapshot);
+    fallbackRanks(snapshot);
 
     if (snapshot.turns.length === 0 && snapshot.rewards.length === 0) {
       return;
@@ -273,6 +328,44 @@
     },
 
     /**
+     * Request a full Thompson Sampling ranking for an experiment.
+     *
+     * Like decide(), but returns the complete sorted arm list instead
+     * of a single winner. Useful for client-side list reordering
+     * (accordions, FAQs, carousels) where the full ranking matters,
+     * not just who is first.
+     *
+     * Same batching, same discipline (read arm ids from the DOM),
+     * same fallback behaviour: on any failure the promise resolves to
+     * the caller-provided arm order so the list stays usable.
+     *
+     * @param {string} experimentId
+     *   The pre-registered experiment id.
+     * @param {Array<string>} armIds
+     *   The arm ids in play. Minimum 2.
+     *
+     * @return {Promise<Array<string>>}
+     *   Resolves to the full sorted arm list (best first). Falls back
+     *   to the caller-provided armIds order on any failure.
+     */
+    rank: function (experimentId, armIds) {
+      if (!Array.isArray(armIds) || armIds.length < 2) {
+        return Promise.reject(new Error('Drupal.rl.rank requires an array of at least 2 arm ids'));
+      }
+      return new Promise(function (resolve) {
+        var entry = queue.ranks[experimentId];
+        if (!entry) {
+          entry = queue.ranks[experimentId] = {
+            arms: armIds.slice(),
+            resolvers: [],
+          };
+        }
+        entry.resolvers.push(resolve);
+        schedule();
+      });
+    },
+
+    /**
      * Record an impression for a variant.
      *
      * @param {string} experimentId
@@ -310,8 +403,8 @@
   // Flush buffered tracking events on navigation so turns and rewards
   // are not lost. visibilitychange covers tab switches and mobile
   // navigation; pagehide covers desktop back/forward cache restoration.
-  // Pending decides are resolved with the fallback arm - the page is
-  // going away so the answer no longer matters.
+  // Pending decides and ranks are resolved with their fallbacks; the
+  // page is going away so the answer no longer matters.
   document.addEventListener('visibilitychange', function () {
     if (document.visibilityState === 'hidden') {
       flushBeacon();

--- a/js/rl.js
+++ b/js/rl.js
@@ -61,12 +61,13 @@
   }
 
   function hasPending() {
-    for (var id in queue.decides) {
+    var id;
+    for (id in queue.decides) {
       if (Object.prototype.hasOwnProperty.call(queue.decides, id)) {
         return true;
       }
     }
-    for (var id in queue.ranks) {
+    for (id in queue.ranks) {
       if (Object.prototype.hasOwnProperty.call(queue.ranks, id)) {
         return true;
       }
@@ -97,13 +98,14 @@
   function buildPayload(snapshot) {
     var decides = [];
     var rankIds = Object.create(null);
-    for (var id in snapshot.ranks) {
+    var id;
+    for (id in snapshot.ranks) {
       if (Object.prototype.hasOwnProperty.call(snapshot.ranks, id)) {
         decides.push({ id: id, arms: snapshot.ranks[id].arms, rank: true });
         rankIds[id] = true;
       }
     }
-    for (var id in snapshot.decides) {
+    for (id in snapshot.decides) {
       if (Object.prototype.hasOwnProperty.call(snapshot.decides, id)) {
         if (!rankIds[id]) {
           decides.push({ id: id, arms: snapshot.decides[id].arms });
@@ -164,7 +166,18 @@
         ranking = decisions[id].ranking;
       }
       if (!ranking) {
-        ranking = entry.arms;
+        ranking = entry.arms.slice();
+        // If the server returned a winner but no ranking (e.g. old
+        // rl.php without rank support), move it to the front so the
+        // caller benefits from the information we do have.
+        if (decisions && decisions[id] && decisions[id].armId) {
+          var winner = decisions[id].armId;
+          var idx = ranking.indexOf(winner);
+          if (idx > 0) {
+            ranking.splice(idx, 1);
+            ranking.unshift(winner);
+          }
+        }
       }
       entry.resolvers.forEach(function (resolve) {
         resolve(ranking);
@@ -338,6 +351,10 @@
      * Same batching, same discipline (read arm ids from the DOM),
      * same fallback behaviour: on any failure the promise resolves to
      * the caller-provided arm order so the list stays usable.
+     *
+     * If both decide() and rank() target the same experiment in one
+     * batch window, they share one wire request using the rank
+     * caller's arm list.
      *
      * @param {string} experimentId
      *   The pre-registered experiment id.

--- a/rl.php
+++ b/rl.php
@@ -281,9 +281,12 @@ function handle_batch_request(array $payload, $registry, $storage, $manager = NU
         continue;
       }
       arsort($scores);
-      $decision = ['armId' => (string) key($scores)];
-      if (!empty($decide['rank'])) {
-        $decision['ranking'] = array_map('strval', array_keys($scores));
+      // Filter to only the requested arms so historical arms that are no
+      // longer in the caller's list do not leak into the response.
+      $ranked = array_values(array_intersect(array_keys($scores), $arm_ids));
+      $decision = ['armId' => (string) $ranked[0]];
+      if (!empty($decide['rank']) && $decide['rank'] === TRUE) {
+        $decision['ranking'] = array_map('strval', $ranked);
       }
       $decisions->{$eid} = $decision;
       $succeeded++;

--- a/rl.php
+++ b/rl.php
@@ -12,14 +12,11 @@
  *     production consumers (ai_sorting, and any third-party JS that was
  *     written before Drupal.rl shipped). These remain fully supported.
  *   - batch: JSON POST body used by Drupal.rl on the client side. Carries
- *     multiple turn and reward events for potentially several experiments
- *     in a single request. See the docblock on handle_batch_request()
- *     below for the payload shape.
- *
- * Deciding which variant to show is an application concern that belongs in
- * PHP at render time (see ai_sorting's Views sort plugin, or
- * VariantSelectorBase in this module). rl.php intentionally does not
- * expose a client-side decide endpoint.
+ *     decides, turns, and rewards for potentially several experiments in
+ *     a single request. Decides return a Thompson Sampling winner per
+ *     experiment; callers may request a full ranking instead of (or in
+ *     addition to) the single winner. See the docblock on
+ *     handle_batch_request() below for the payload shape.
  */
 
 use Drupal\Core\DrupalKernel;
@@ -176,6 +173,7 @@ catch (\Exception $e) {
  * {
  *   "decides": [
  *     {"id": "<experiment_id>", "arms": ["<arm>", "<arm>", ...]},
+ *     {"id": "<experiment_id>", "arms": [...], "rank": true},
  *     ...
  *   ],
  *   "turns":   [{"id": "<experiment_id>", "arm": "<arm>"}, ...],
@@ -188,6 +186,16 @@ catch (\Exception $e) {
  * @code
  * {"decisions": {"<experiment_id>": {"armId": "<arm>"}, ...}}
  * @endcode
+ *
+ * When `"rank": true` is set on a decide entry, the response includes
+ * the full sorted arm list alongside the winner:
+ * @code
+ * {"decisions": {"<eid>": {"armId": "<arm>", "ranking": ["<arm>", ...]}}}
+ * @endcode
+ *
+ * `armId` always equals `ranking[0]`. Callers that only need a single
+ * winner can ignore `ranking`; callers that need a full ordering (e.g.
+ * client-side list sorting) read `ranking` instead.
  *
  * Rejected entries are recorded in `errors` with a machine-readable
  * `reason` (unknown_experiment, invalid_arm_id, missing_arms,
@@ -273,7 +281,11 @@ function handle_batch_request(array $payload, $registry, $storage, $manager = NU
         continue;
       }
       arsort($scores);
-      $decisions->{$eid} = ['armId' => (string) key($scores)];
+      $decision = ['armId' => (string) key($scores)];
+      if (!empty($decide['rank'])) {
+        $decision['ranking'] = array_map('strval', array_keys($scores));
+      }
+      $decisions->{$eid} = $decision;
       $succeeded++;
     }
   }


### PR DESCRIPTION
## Summary

Closes #59.

The batch endpoint (`rl.php`) computed full Thompson Sampling scores for all arms but only returned the single winner (`armId`). Client-side consumers that need a complete ranking (for reordering lists like FAQ accordions, carousels, or toggle items by engagement) had no way to get one without burning page cache.

This PR adds a backwards-compatible `rank` flag to the batch protocol and a new `Drupal.rl.rank()` JS method:

- **`rl.php`**: when a decide entry carries `"rank": true`, the response includes a `ranking` array (all arms sorted by score, best first) alongside the existing `armId`. The `ranking` field is only present when requested; `armId` always equals `ranking[0]`. No change for existing consumers.
- **`rl.js`**: new `Drupal.rl.rank(experimentId, armIds)` method returns `Promise<string[]>`. Same batching (500ms coalescing), same discipline (read arm IDs from the DOM), same fallback behaviour (resolves to caller-provided order on any failure). When both `decide()` and `rank()` target the same experiment in one batch window, they share a single wire request.
- **Docs**: README.md and `docs/rl_project_desc.html` updated with `rank()` examples, `rank` vs `decide` guidance, and updated HTTP API payload/response docs.

### Adjacent improvements
- Fixed stale file-level docblock in `rl.php` that incorrectly stated decides were not exposed
- Fixed a pre-existing em dash lint violation in `rl.js`
- Added "engagement-ranked lists" to the use cases in README and project description
- Updated batch action table description to reflect that `batch` carries decides (not just "record turns and rewards")

### Backwards compatibility
- Fully BC: the `ranking` field is opt-in per decide entry; existing consumers see no change
- `armId` remains the primary response field and is always present
- `Drupal.rl.decide()` behaviour is unchanged
- No schema, config, or database changes

## Test plan
- [ ] Verify `Drupal.rl.decide()` still works unchanged (single winner returned)
- [ ] Call `Drupal.rl.rank(eid, ['a','b','c'])` and confirm the promise resolves to a sorted array of all three arms
- [ ] Confirm `rank()` falls back to the caller-provided order when the endpoint is unreachable
- [ ] Send a batch request with `"rank": true` via curl and confirm `ranking` appears in the response alongside `armId`
- [ ] Send a batch request without `"rank"` and confirm no `ranking` field in response
- [ ] Test both `decide()` and `rank()` for the same experiment in one page load; confirm single wire request
- [ ] Verify beacon fallback resolves rank promises with authored order