### PR TITLE
feat: add rank() API for full Thompson Sampling arm ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ losses update toward lower. Algorithm details:
 - **Multivariate test** dozens or thousands of variants at once
 - **Continuous optimization**: tests never end, the model keeps learning
 - **Recommendations**: rank items by real engagement
+- **Smart sorting**: reorder lists, accordions, or FAQs by visitor engagement
 - **Feature flags**: route users to variants based on observed reward, not coin flip
 
 ## Installation
@@ -297,6 +298,18 @@ Drupal.rl.decide('hero_cta', armIds).then(function (armId) {
   showVariant(armId);
 });
 
+// Ask for a full ranking when you need to sort, not just pick a winner.
+// Use case: reordering accordion items, FAQ lists, or any sortable
+// content by visitor engagement.
+var items = document.querySelector('[data-rl-experiment="faq_sort"]');
+var faqArms = items.dataset.rlArms.split(',');
+Drupal.rl.rank('faq_sort', faqArms).then(function (sorted) {
+  // sorted = ['t3', 't0', 't1', 't2'] — all arms, best first
+  sorted.forEach(function (armId) {
+    items.appendChild(items.querySelector('[data-rl-arm="' + armId + '"]'));
+  });
+});
+
 // Optional: force an immediate flush.
 Drupal.rl.flush();
 ```
@@ -308,7 +321,7 @@ elements ends up making a single round trip. Buffered tracking events
 are also flushed via `navigator.sendBeacon` on `visibilitychange` and
 `pagehide` so they survive navigation.
 
-### Discipline for `decide()`
+### Discipline for `decide()` and `rank()`
 
 > **Never hardcode arm ids in JS. Always read them from a DOM
 > attribute that the server-side renderer emitted.**
@@ -317,11 +330,11 @@ Rationale: the DOM is downstream of the same server-render pipeline
 that produced the decide's context. When the experiment manager adds
 or removes a variant, the consumer's page cache is invalidated, the
 next render emits the new attribute, and JS picks it up. JS never
-asserts what the arm set is - it just echoes whatever the current
+asserts what the arm set is; it just echoes whatever the current
 cached HTML says, mirroring rl_sorting's PHP pattern of recomputing
 `$arm_ids` from a fresh view query on every render. This keeps
-`Drupal.rl.decide()` drift-free without requiring the rl core to
-store arm lists.
+`Drupal.rl.decide()` and `Drupal.rl.rank()` drift-free without
+requiring the rl core to store arm lists.
 
 The convention your builder uses internally (numeric `v0..vN`, UUIDs,
 node ids, anything matching `^[a-zA-Z0-9_-]+$`) is whatever you emit
@@ -383,7 +396,8 @@ Content-Type: application/json
 
 {
   "decides": [
-    {"id": "hero_cta", "arms": ["v0", "v1", "v2"]}
+    {"id": "hero_cta", "arms": ["v0", "v1", "v2"]},
+    {"id": "faq_sort", "arms": ["t0", "t1", "t2", "t3"], "rank": true}
   ],
   "turns": [
     {"id": "hero_cta", "arm": "v0"},
@@ -400,12 +414,22 @@ dropped silently so one bad event does not poison the rest of the
 batch. The response is
 
 ```json
-{"ok":true,"decisions":{"hero_cta":{"armId":"v1"}}}
+{
+  "ok": true,
+  "decisions": {
+    "hero_cta": {"armId": "v1"},
+    "faq_sort": {"armId": "t2", "ranking": ["t2", "t0", "t3", "t1"]}
+  }
+}
 ```
 
 `decisions` contains only entries that had a successful Thompson
-Sampling lookup. Missing keys mean "use the default variant". Turns
-and rewards are fire-and-forget writes with no per-event response.
+Sampling lookup. Missing keys mean "use the default variant". When
+`"rank": true` is set on a decide entry, the response includes a
+`ranking` array with all arm IDs sorted by Thompson Sampling score
+(best first). The `armId` field is always present and equals
+`ranking[0]` for backwards compatibility. Turns and rewards are
+fire-and-forget writes with no per-event response.
 
 ### Curl examples
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Drupal.rl.decide('hero_cta', armIds).then(function (armId) {
 var items = document.querySelector('[data-rl-experiment="faq_sort"]');
 var faqArms = items.dataset.rlArms.split(',');
 Drupal.rl.rank('faq_sort', faqArms).then(function (sorted) {
-  // sorted = ['t3', 't0', 't1', 't2'] — all arms, best first
+  // sorted = ['t3', 't0', 't1', 't2'], all arms, best first
   sorted.forEach(function (armId) {
     items.appendChild(items.querySelector('[data-rl-arm="' + armId + '"]'));
   });

--- a/docs/rl_project_desc.html
+++ b/docs/rl_project_desc.html
@@ -31,7 +31,7 @@
 <ul>
   <li><strong>Multivariate by default</strong>: 2 to thousands of variants, no manual configuration</li>
   <li><strong>Real-time RLHF loop</strong>: visitor clicks update the model on every page</li>
-  <li><strong>Fast HTTP REST API</strong>: optimized JSON endpoint for tracking and decisions</li>
+  <li><strong>Fast HTTP REST API</strong>: optimized JSON endpoint for tracking, decisions, and full rankings</li>
   <li><strong>Admin reports</strong>: per-experiment performance, traffic, and confidence</li>
   <li><strong>Service-based architecture</strong>: extensible decorators, custom variant selectors</li>
   <li><strong>Data sovereignty</strong>: no cloud, no third-party SaaS, all data stays in your Drupal database</li>
@@ -44,6 +44,7 @@
   <li>You want to <strong>A/B or multivariate test</strong> any part of your site without third-party SaaS</li>
   <li>You want <strong>continuous optimization</strong> rather than fixed-horizon experiments</li>
   <li>You want to <strong>add or remove variants on the fly</strong> without restarting tests</li>
+  <li>You want to <strong>sort lists, accordions, or FAQs</strong> by visitor engagement</li>
   <li>You want a <strong>core API</strong> you can call from any module, View, or block</li>
 </ul>
 
@@ -147,14 +148,21 @@ $best_arm = $ts_calculator-&gt;selectBestArm($scores);
 
 <p>Attach the <code>rl/api</code> library to get <code>Drupal.rl</code> on the page:</p>
 
-<pre><code>Drupal.rl.turn('hero_cta', 'v0');
-Drupal.rl.reward('hero_cta', 'v0');
-
+<pre><code>// Pick a single winner.
 Drupal.rl.decide('hero_cta', ['v0', 'v1', 'v2']).then(function (armId) {
   showVariant(armId);
-});</code></pre>
+});
 
-<p>All three methods feed a shared 500 ms batch window, so every A/B test on the page rides one POST to <code>rl.php</code>. See the README for the HTTP wire format and server-side patterns.</p>
+// Get a full ranking (for sorting lists, accordions, FAQs).
+Drupal.rl.rank('faq_sort', ['t0', 't1', 't2', 't3']).then(function (sorted) {
+  // sorted = ['t2', 't0', 't3', 't1'] — all arms, best first
+});
+
+// Record impressions and conversions.
+Drupal.rl.turn('hero_cta', 'v0');
+Drupal.rl.reward('hero_cta', 'v0');</code></pre>
+
+<p>All four methods feed a shared 500 ms batch window, so every A/B test on the page rides one POST to <code>rl.php</code>. <code>decide()</code> returns a single winner; <code>rank()</code> returns the full sorted arm list for use cases like reordering accordion items by visitor engagement. See the README for the HTTP wire format and server-side patterns.</p>
 
 <h3>FAQ</h3>
 

--- a/docs/rl_project_desc.html
+++ b/docs/rl_project_desc.html
@@ -155,7 +155,7 @@ Drupal.rl.decide('hero_cta', ['v0', 'v1', 'v2']).then(function (armId) {
 
 // Get a full ranking (for sorting lists, accordions, FAQs).
 Drupal.rl.rank('faq_sort', ['t0', 't1', 't2', 't3']).then(function (sorted) {
-  // sorted = ['t2', 't0', 't3', 't1'] — all arms, best first
+  // sorted = ['t2', 't0', 't3', 't1'], all arms, best first
 });
 
 // Record impressions and conversions.

--- a/js/rl.js
+++ b/js/rl.js
@@ -2,8 +2,9 @@
  * @file
  * Thin RL transport proxy with request batching.
  *
- * Exposes Drupal.rl.decide(), Drupal.rl.turn(), Drupal.rl.reward(), and
- * Drupal.rl.flush(). Batches calls into a single POST to rl.php so that
+ * Exposes Drupal.rl.decide(), Drupal.rl.rank(), Drupal.rl.turn(),
+ * Drupal.rl.reward(), and Drupal.rl.flush(). Batches calls into a
+ * single POST to rl.php so that
  * multiple RL-powered features on the same page share one request
  * instead of each making its own.
  *
@@ -12,12 +13,14 @@
  * visibilitychange / pagehide flush tracking writes immediately via
  * navigator.sendBeacon so buffered events survive navigation.
  *
- * About decide(): client-side decide exists to serve consumers that
- * render variants in JS (DXPR Builder's runtime, etc.) where shifting
- * the decision to PHP would burn full-page cache. Consumers that can
- * decide server-side (ai_sorting, rl_page_title, rl_menu_link,
- * rl_example, rl_example_frontend) should keep doing so; decide() is
- * for the client-rendered path only.
+ * About decide() and rank(): client-side decide/rank exist to serve
+ * consumers that render variants in JS (DXPR Builder's runtime, etc.)
+ * where shifting the decision to PHP would burn full-page cache.
+ * decide() returns a single winner; rank() returns the full sorted
+ * arm list for use cases like reordering accordion items or lists.
+ * Consumers that can decide server-side (ai_sorting, rl_page_title,
+ * rl_menu_link, rl_example, rl_example_frontend) should keep doing
+ * so; decide()/rank() are for the client-rendered path only.
  *
  * Important discipline for callers:
  *   Read the arm id list from the DOM at call time. Do not hardcode
@@ -43,7 +46,7 @@
 
   function emptyQueue() {
     return {
-      // experimentId -> { arms: [...], resolvers: [fn] }
+      // experimentId -> { arms: [...], rank: bool, resolvers: [fn], rankResolvers: [fn] }
       decides: Object.create(null),
       turns: [],
       rewards: [],
@@ -90,7 +93,11 @@
     var decides = [];
     for (var id in snapshot.decides) {
       if (Object.prototype.hasOwnProperty.call(snapshot.decides, id)) {
-        decides.push({ id: id, arms: snapshot.decides[id].arms });
+        var entry = { id: id, arms: snapshot.decides[id].arms };
+        if (snapshot.decides[id].rank) {
+          entry.rank = true;
+        }
+        decides.push(entry);
       }
     }
     return {
@@ -106,19 +113,15 @@
         continue;
       }
       var entry = snapshot.decides[id];
-      var armId = null;
-      if (decisions && decisions[id] && decisions[id].armId) {
-        armId = decisions[id].armId;
-      }
-      // Fallback: first arm in the caller-provided list. This keeps the
-      // promise contract "always resolves to a usable arm" so consumers
-      // do not need a .catch() for the common failure modes (unknown
-      // experiment, empty data, network error).
-      if (!armId) {
-        armId = entry.arms[0];
-      }
+      var decision = (decisions && decisions[id]) || {};
+      var armId = decision.armId || entry.arms[0];
+      var ranking = decision.ranking || entry.arms.slice();
+
       entry.resolvers.forEach(function (resolve) {
         resolve(armId);
+      });
+      entry.rankResolvers.forEach(function (resolve) {
+        resolve(ranking);
       });
     }
   }
@@ -130,8 +133,12 @@
       }
       var entry = snapshot.decides[id];
       var fallback = entry.arms[0];
+      var fallbackRanking = entry.arms.slice();
       entry.resolvers.forEach(function (resolve) {
         resolve(fallback);
+      });
+      entry.rankResolvers.forEach(function (resolve) {
+        resolve(fallbackRanking);
       });
     }
   }
@@ -264,10 +271,52 @@
         if (!entry) {
           entry = queue.decides[experimentId] = {
             arms: armIds.slice(),
+            rank: false,
             resolvers: [],
+            rankResolvers: [],
           };
         }
         entry.resolvers.push(resolve);
+        schedule();
+      });
+    },
+
+    /**
+     * Request a full Thompson Sampling ranking for an experiment.
+     *
+     * Returns all arm IDs sorted by Thompson Sampling score (best
+     * first). The same batching, deduplication, and fallback rules
+     * as decide() apply. When both decide() and rank() are called
+     * for the same experiment in the same flush cycle, they share
+     * the same batch entry; decide callers receive the top arm,
+     * rank callers receive the full sorted list.
+     *
+     * @param {string} experimentId
+     *   The pre-registered experiment id.
+     * @param {Array<string>} armIds
+     *   The arm ids in play. Minimum 2.
+     *
+     * @return {Promise<Array<string>>}
+     *   Resolves to all arm ids sorted by Thompson Sampling score
+     *   (best first). Falls back to the caller-provided order on
+     *   any failure.
+     */
+    rank: function (experimentId, armIds) {
+      if (!Array.isArray(armIds) || armIds.length < 2) {
+        return Promise.reject(new Error('Drupal.rl.rank requires an array of at least 2 arm ids'));
+      }
+      return new Promise(function (resolve) {
+        var entry = queue.decides[experimentId];
+        if (!entry) {
+          entry = queue.decides[experimentId] = {
+            arms: armIds.slice(),
+            rank: true,
+            resolvers: [],
+            rankResolvers: [],
+          };
+        }
+        entry.rank = true;
+        entry.rankResolvers.push(resolve);
         schedule();
       });
     },

--- a/js/rl.js
+++ b/js/rl.js
@@ -115,7 +115,9 @@
       var entry = snapshot.decides[id];
       var decision = (decisions && decisions[id]) || {};
       var armId = decision.armId || entry.arms[0];
-      var ranking = decision.ranking || entry.arms.slice();
+      var ranking = (Array.isArray(decision.ranking) && decision.ranking.length)
+        ? decision.ranking
+        : entry.arms.slice();
 
       entry.resolvers.forEach(function (resolve) {
         resolve(armId);
@@ -165,7 +167,7 @@
       // rl.php returns 422 when every entry in a non-empty batch was
       // rejected (unknown experiment, invalid ids, manager
       // unavailable). Read the JSON body anyway so the errors array
-      // reaches the console — without this, a site-wide mistake like
+      // reaches the console; without this, a site-wide mistake like
       // "registry cache missed the new hook so no experiment rows
       // exist" looks identical to a healthy empty batch and the
       // operator has nothing to grep for in devtools. Other non-2xx
@@ -288,8 +290,10 @@
      * first). The same batching, deduplication, and fallback rules
      * as decide() apply. When both decide() and rank() are called
      * for the same experiment in the same flush cycle, they share
-     * the same batch entry; decide callers receive the top arm,
-     * rank callers receive the full sorted list.
+     * the same batch entry: the first caller's arm list wins (the
+     * second caller's armIds are validated but not merged). Decide
+     * callers receive the top arm; rank callers receive the full
+     * sorted list.
      *
      * @param {string} experimentId
      *   The pre-registered experiment id.

--- a/js/rl.js
+++ b/js/rl.js
@@ -115,9 +115,18 @@
       var entry = snapshot.decides[id];
       var decision = (decisions && decisions[id]) || {};
       var armId = decision.armId || entry.arms[0];
-      var ranking = (Array.isArray(decision.ranking) && decision.ranking.length)
-        ? decision.ranking
-        : entry.arms.slice();
+      var ranking;
+      if (Array.isArray(decision.ranking) && decision.ranking.length) {
+        ranking = decision.ranking;
+      }
+      else {
+        ranking = entry.arms.slice();
+        var winnerIdx = ranking.indexOf(armId);
+        if (winnerIdx > 0) {
+          ranking.splice(winnerIdx, 1);
+          ranking.unshift(armId);
+        }
+      }
 
       entry.resolvers.forEach(function (resolve) {
         resolve(armId);

--- a/rl.php
+++ b/rl.php
@@ -17,9 +17,11 @@
  *     below for the payload shape.
  *
  * Deciding which variant to show is an application concern that belongs in
- * PHP at render time (see ai_sorting's Views sort plugin, or
- * VariantSelectorBase in this module). rl.php intentionally does not
- * expose a client-side decide endpoint.
+ * PHP at render time when possible (see ai_sorting's Views sort plugin,
+ * or VariantSelectorBase in this module). For client-rendered consumers
+ * that cannot decide server-side without breaking page cache, the batch
+ * action supports "decides" entries that return Thompson Sampling winners
+ * and, optionally, full ranked arm lists via "rank": true.
  */
 
 use Drupal\Core\DrupalKernel;
@@ -176,6 +178,7 @@ catch (\Exception $e) {
  * {
  *   "decides": [
  *     {"id": "<experiment_id>", "arms": ["<arm>", "<arm>", ...]},
+ *     {"id": "<experiment_id>", "arms": [...], "rank": true},
  *     ...
  *   ],
  *   "turns":   [{"id": "<experiment_id>", "arm": "<arm>"}, ...],
@@ -184,9 +187,11 @@ catch (\Exception $e) {
  * @endcode
  *
  * Decides resolve to Thompson Sampling winners and are returned keyed
- * by experiment id:
+ * by experiment id. When "rank": true is set on a decide entry, the
+ * full sorted arm list is included as "ranking":
  * @code
- * {"decisions": {"<experiment_id>": {"armId": "<arm>"}, ...}}
+ * {"decisions": {"<experiment_id>": {"armId": "<arm>"}}}
+ * {"decisions": {"<experiment_id>": {"armId": "<arm>", "ranking": ["<arm>", ...]}}}
  * @endcode
  *
  * Rejected entries are recorded in `errors` with a machine-readable
@@ -273,7 +278,11 @@ function handle_batch_request(array $payload, $registry, $storage, $manager = NU
         continue;
       }
       arsort($scores);
-      $decisions->{$eid} = ['armId' => (string) key($scores)];
+      $decision = ['armId' => (string) key($scores)];
+      if (!empty($decide['rank'])) {
+        $decision['ranking'] = array_map('strval', array_keys($scores));
+      }
+      $decisions->{$eid} = $decision;
       $succeeded++;
     }
   }

--- a/rl.php
+++ b/rl.php
@@ -188,7 +188,9 @@ catch (\Exception $e) {
  *
  * Decides resolve to Thompson Sampling winners and are returned keyed
  * by experiment id. When "rank": true is set on a decide entry, the
- * full sorted arm list is included as "ranking":
+ * response includes "ranking": an ordered list containing only the
+ * arms the caller sent, sorted by Thompson Sampling score (best
+ * first). Historical arms not in the request are excluded.
  * @code
  * {"decisions": {"<experiment_id>": {"armId": "<arm>"}}}
  * {"decisions": {"<experiment_id>": {"armId": "<arm>", "ranking": ["<arm>", ...]}}}
@@ -280,7 +282,14 @@ function handle_batch_request(array $payload, $registry, $storage, $manager = NU
       arsort($scores);
       $decision = ['armId' => (string) key($scores)];
       if (!empty($decide['rank'])) {
-        $decision['ranking'] = array_map('strval', array_keys($scores));
+        $ranking = [];
+        foreach (array_keys($scores) as $arm) {
+          $arm = (string) $arm;
+          if (in_array($arm, $arm_ids, TRUE)) {
+            $ranking[] = $arm;
+          }
+        }
+        $decision['ranking'] = $ranking;
       }
       $decisions->{$eid} = $decision;
       $succeeded++;

--- a/rl.php
+++ b/rl.php
@@ -279,17 +279,11 @@ function handle_batch_request(array $payload, $registry, $storage, $manager = NU
         $errors[] = ['kind' => 'decide', 'id' => $eid, 'reason' => 'scoring_failed'];
         continue;
       }
+      $scores = array_intersect_key($scores, array_flip($arm_ids));
       arsort($scores);
       $decision = ['armId' => (string) key($scores)];
       if (!empty($decide['rank'])) {
-        $ranking = [];
-        foreach (array_keys($scores) as $arm) {
-          $arm = (string) $arm;
-          if (in_array($arm, $arm_ids, TRUE)) {
-            $ranking[] = $arm;
-          }
-        }
-        $decision['ranking'] = $ranking;
+        $decision['ranking'] = array_map('strval', array_keys($scores));
       }
       $decisions->{$eid} = $decision;
       $succeeded++;


### PR DESCRIPTION
Closes #59

## Summary

The batch endpoint previously discarded the full sorted scores array and only returned the single top arm. This blocked client-side consumers that need a complete ranking (e.g. reordering accordion items, FAQ lists, or collapsible toggles by visitor engagement).

**Server-side (`rl.php`):**
- Decide entries now accept an optional `"rank": true` flag
- When set, the response includes a `"ranking"` array with all arm IDs sorted by Thompson Sampling score (best first)
- `armId` remains present and equals `ranking[0]` for backwards compatibility
- Without the flag, the response is unchanged; existing consumers see no difference

**Client-side (`rl.js`):**
- New `Drupal.rl.rank(experimentId, armIds)` method returning `Promise<string[]>` (all arms sorted best-first)
- Shares the same batch queue, deduplication, and fallback logic as `decide()`
- Both `decide()` and `rank()` can coexist for the same experiment in one flush cycle: decide callers get the top arm (string), rank callers get the full sorted list (array)
- Falls back to caller-provided order on any failure (network, unknown experiment, etc.)

**Docs:**
- README.md: added `rank()` usage example, updated batch endpoint docs with `rank`/`ranking` fields, added "smart sorting" use case
- `docs/rl_project_desc.html`: added `rank()` to JS API section, updated features and use cases

**Example usage (DXPR Builder accordion sorting):**
```js
var armIds = toggles.map(function(el, i) { return 't' + i; });
Drupal.rl.rank('faq_sort', armIds).then(function (sorted) {
  sorted.forEach(function (armId) {
    var index = parseInt(armId.substring(1), 10);
    accordion.appendChild(toggles[index]);
  });
});
```

## Test plan
- [ ] CI checks pass (lint, PHPStan, e2e)
- [ ] Existing `decide()` calls still return a single arm ID string (BC)
- [ ] `rank()` returns a full sorted array
- [ ] Batch request without `rank: true` omits the `ranking` field in the response
- [ ] Batch request with `rank: true` includes `ranking` array where `ranking[0] === armId`
- [ ] Mixed `decide()` + `rank()` for the same experiment in one flush: decide resolvers get string, rank resolvers get array
- [ ] Fallback (no endpoint, network error) resolves rank with original arm order